### PR TITLE
Fixed double free on rows Close

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -228,10 +228,6 @@ type SQLiteRows struct {
 }
 
 func (rc *SQLiteRows) Close() error {
-	rv := C.sqlite3_finalize(rc.s.s)
-	if rv != C.SQLITE_OK {
-		return errors.New(C.GoString(C.sqlite3_errmsg(rc.s.c.db)))
-	}
 	return nil
 }
 


### PR DESCRIPTION
Rows should not close the statement because Stmt has its own close
function. This caused a double free error/crash on Fedora 16 x86_64.

The problem was also mentioned here:
http://code.google.com/p/go/source/detail?r=0b2effea81af340f9c18f16685aa9c365c2d2b10
