### PR TITLE
Fix invalid memory read in Close()

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -108,7 +108,7 @@ func (c *SQLiteConn) Close() error {
 	s := C.sqlite3_next_stmt(c.db, nil)
 	for s != nil {
 		C.sqlite3_finalize(s)
-		s = C.sqlite3_next_stmt(c.db, s)
+		s = C.sqlite3_next_stmt(c.db, nil)
 	}
 	rv := C.sqlite3_close(c.db)
 	if rv != C.SQLITE_OK {


### PR DESCRIPTION
After calling sqlite3_finalize(s), it isn't safe to pass s into sqlite3_next_stmt() on the next line. When running under valgrind on Linux, this shows up as an invalid memory read.
