### PR TITLE
Travis-CI simplification

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/cookieo9/go-sqlite3"
+	_ "github.com/mattn/go-sqlite3"
 	"os"
 )
 


### PR DESCRIPTION
Travis-ci.org now supports go natively, so the .travis.yml file can be collapsed into a single line:

language: go

Also, since it no longer needs to grab & build go first the testing time drops to < 20s.
