### PR TITLE
Add support for extracting 2006-01-02 formatted timestamps.

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -27,6 +27,7 @@ import (
 )
 
 const SQLiteTimestampFormat = "2006-01-02 15:04:05"
+const SQLiteDateFormat = "2006-01-02"
 
 func init() {
 	sql.Register("sqlite3", &SQLiteDriver{})
@@ -313,7 +314,10 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 			if rc.decltype[i] == "timestamp" {
 				dest[i], err = time.Parse(SQLiteTimestampFormat, s)
 				if err != nil {
-					return err
+					dest[i], err = time.Parse(SQLiteDateFormat, s)
+					if err != nil {
+						return err
+					}
 				}
 			} else {
 				dest[i] = s


### PR DESCRIPTION
SQLite3 stores timestamps very naively -- they're completely untyped,
and can contain any value. The previous implementation always inserts
values in the 'datetime' format, and returns an error when attempting to
extract a field with a different format.

Some legacy databases, unfortunately, were generated using the 'date'
SQLite3 function, which produces rows in the '2006-01-02' format. This
patch adds a special case so that these rows can be extracted without
error.

I don't know if merging this is good for the library; there are infinitely more
special cases that SQLite3 can have for timestamps (because it stores
them as strings and doesn't really care how they're encoded). For all
date/time functions, SQLite3 supports the following encodings[1] --
- YYYY-MM-DD
- YYYY-MM-DD HH:MM
- YYYY-MM-DD HH:MM:SS
- YYYY-MM-DD HH:MM:SS.SSS
- YYYY-MM-DDTHH:MM
- YYYY-MM-DDTHH:MM:SS
- YYYY-MM-DDTHH:MM:SS.SSS
- HH:MM
- HH:MM:SS
- HH:MM:SS.SSS
- now
- DDDDDDDDDD

A correct patch, IMO, would add support for all SQLite3-supported encodings
which would be really gross (too many special cases) and does not fix the
original problem -- the database is effectively already corrupt.

I just thought I'd share the patch if anyone wants it.

---

[1] [SQLite3 Date And Time Functions](http://www.sqlite.org/lang_datefunc.html)
