### PR TITLE
Fix #33 and #34

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -213,7 +213,7 @@ func (s *SQLiteStmt) bind(args []driver.Value) error {
 			}
 			rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(p), C.int(len(v)))
 		case time.Time:
-			b := []byte(v.Format(SQLiteTimestampFormat))
+			b := []byte(v.UTC().Format(SQLiteTimestampFormat))
 			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
 		}
 		if rv != C.SQLITE_OK {

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -267,6 +267,12 @@ func TestTimestamp(t *testing.T) {
 		t.Fatal("Failed to insert nonsense:", err)
 	}
 
+	timestamp4 := time.Date(2012, time.April, 6, 23, 22, 0, 0, time.FixedZone("TEST", -7*3600))
+	_, err = db.Exec("INSERT INTO foo(id, ts) VALUES(4, ?)", timestamp4)
+	if err != nil {
+		t.Fatal("Failed to insert timestamp:", err)
+	}
+
 	rows, err := db.Query("SELECT id, ts FROM foo ORDER BY id ASC")
 	if err != nil {
 		t.Fatal("Unable to query foo table:", err)
@@ -303,10 +309,17 @@ func TestTimestamp(t *testing.T) {
 				t.Errorf("Value for id 3 should be the zero time, not %v", ts)
 			}
 		}
+
+		if id == 4 {
+			seen += 1
+			if !timestamp4.Equal(ts) {
+				t.Errorf("Value for id 4 should be %v, not %v", timestamp4, ts)
+			}
+		}
 	}
 
-	if seen != 3 {
-		t.Error("Expected to see three timestamps")
+	if seen != 4 {
+		t.Error("Expected to see four timestamps")
 	}
 }
 


### PR DESCRIPTION
This change makes (*SQLiteRows).Next always return a time.Time for integer or string values in columns of declared type "timestamp" or "datetime". If a string value can't be parsed, the zero time is returned. This makes the (slightly modified) tests pass.
