### PR TITLE
call sqlite3_column_blob() before sqlite3_column_bytes()

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -373,8 +373,8 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 		case C.SQLITE_FLOAT:
 			dest[i] = float64(C.sqlite3_column_double(rc.s.s, C.int(i)))
 		case C.SQLITE_BLOB:
-			n := int(C.sqlite3_column_bytes(rc.s.s, C.int(i)))
 			p := C.sqlite3_column_blob(rc.s.s, C.int(i))
+			n := int(C.sqlite3_column_bytes(rc.s.s, C.int(i)))
 			switch dest[i].(type) {
 			case sql.RawBytes:
 				dest[i] = (*[1 << 30]byte)(unsafe.Pointer(p))[0:n]


### PR DESCRIPTION
sqlite3 documentation states sqlite3_column_blob could modify the
the content and recommends the "safest and easiest" policy is to
invoke sqlite3_column_blob() followed by sqlite3_column_bytes()

from: http://www.sqlite.org/c3ref/column_blob.html
