### PR TITLE
Fix example bug

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -83,7 +83,7 @@ func main() {
 		return
 	}
 
-	_, err = db.Exec("insert into foo(id, name) values(1, 'foo'), (2, 'bar'), (3, 'baz')")
+	_, err = db.Exec("insert into foo(id, name) select 1, 'foo' union all select 2, 'bar' union all select 3, 'baz'")
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
*sqlite unsupport bulk insert like below, it not standard SQL:
    INSERT INTO TABLE(col1, col2) VALUES(val11, val12), (val21, val22) ;

*sqlite support bulk insert like below:
    INSERT INTO TABLE(col1, col2) SELECT val11, val12 UNION ALL SELECT
    val21, val22;
