### PR TITLE
Added error return to ConnectHook and fixed extension example

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -78,7 +78,7 @@ func init() {
 // Driver struct.
 type SQLiteDriver struct {
 	EnableLoadExtension bool
-	ConnectHook func(*SQLiteConn)
+	ConnectHook         func(*SQLiteConn) error
 }
 
 // Conn struct.
@@ -194,7 +194,9 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	conn := &SQLiteConn{db}
 
 	if d.ConnectHook != nil {
-		d.ConnectHook(conn)
+		if err := d.ConnectHook(conn); err != nil {
+			return nil, err
+		}
 	}
 
 	return conn, nil


### PR DESCRIPTION
The ConnectHook field of an SQLiteDriver should return an error in
case something bad happened during the hook.

The extension example needs to load the extension in a ConnectHook,
otherwise the extension is only loaded in a single connection in the pool.
By putting the extension loading in the ConnectHook, its called for every
connection that is opened by the sql.DB.

Update #71 in mattn/go-sqlite3
