### PR TITLE
Change extension loading mechanism to use a string list of extensions

### DIFF
--- a/example/extension/extension.go
+++ b/example/extension/extension.go
@@ -8,29 +8,10 @@ import (
 )
 
 func main() {
-	const (
-		use_hook = true
-		load_query = "SELECT load_extension('sqlite3_mod_regexp.dll')"
-	)
-
 	sql.Register("sqlite3_with_extensions",
 		&sqlite3.SQLiteDriver{
-			EnableLoadExtension: true,
-			ConnectHook: func(c *sqlite3.SQLiteConn) error {
-				if use_hook {
-					stmt, err := c.Prepare(load_query)
-					if err != nil {
-						return err
-					}
-
-					_, err = stmt.Exec(nil)
-					if err != nil {
-						return err
-					}
-
-					return stmt.Close()
-				}
-				return nil
+			Extensions: []string{
+				"sqlite3_mod_regexp.dll",
 			},
 		})
 
@@ -39,12 +20,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	if !use_hook {
-		if _, err = db.Exec(load_query); err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	// Force db to make a new connection in pool
 	// by putting the original in a transaction


### PR DESCRIPTION
To make dealing with extensions (issue #71) easier to do and harder to get wrong, the mechanism is changed so that a string list of extensions to be loaded is set on the SQLite3Driver. This also closes a potential security hole since the extension loading feature of sqlite is only enabled while the extensions are loaded, and is then disabled before the user gets their hands on the connection.
