### PR TITLE
Next(): populate Row with []byte instead of string, as per driver doc

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -525,7 +525,7 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 					dest[i] = time.Time{}
 				}
 			default:
-				dest[i] = s
+				dest[i] = []byte(s)
 			}
 
 		}


### PR DESCRIPTION
Fix on behalf of bradfitz, see
http://golang.org/pkg/database/sql/driver/#Rows
