### PR TITLE
Enable Sqlite R*Tree Module

### DIFF
--- a/sqlite3_other.go
+++ b/sqlite3_other.go
@@ -5,5 +5,6 @@ package sqlite3
 /*
 #cgo CFLAGS: -I.
 #cgo linux LDFLAGS: -ldl
+#cgo CFLAGS: -DSQLITE_ENABLE_RTREE
 */
 import "C"

--- a/sqlite3_windows.go
+++ b/sqlite3_windows.go
@@ -3,5 +3,6 @@ package sqlite3
 /*
 #cgo CFLAGS: -I. -fno-stack-check -fno-stack-protector -mno-stack-arg-probe
 #cgo LDFLAGS: -lmingwex -lmingw32
+#cgo CFLAGS: -DSQLITE_ENABLE_RTREE
 */
 import "C"


### PR DESCRIPTION
The [SQLite R*Tree Module](http://www.sqlite.org/rtree.html) is needed for geospatial applications, as geospatial table indices cannot use binary trees. It can simply be enabled at compile time as it is included in the SQLite amalgamation by default. Enabling it should has no side effects to existing applications, except adding a few KB to the resulting binaries.
