### PR TITLE
Added an IsDone method for backup

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -13,15 +13,6 @@ type Backup struct {
 	b *C.sqlite3_backup
 }
 
-func IsDone(err error) bool {
-	sqlErr, ok := err.(Error)
-	if !ok {
-		return false
-	}
-
-	return sqlErr.Code == ErrDone
-}
-
 func (c *SQLiteConn) Backup(dest string, conn *SQLiteConn, src string) (*Backup, error) {
 	destptr := C.CString(dest)
 	defer C.free(unsafe.Pointer(destptr))
@@ -34,12 +25,18 @@ func (c *SQLiteConn) Backup(dest string, conn *SQLiteConn, src string) (*Backup,
 	return nil, c.lastError()
 }
 
-func (b *Backup) Step(p int) error {
+// Backs up for one step. Calls the underlying `sqlite3_backup_step` function.
+// This function returns a boolean indicating if the backup is done and
+// an error signalling any other error. Done is returned if the underlying C
+// function returns SQLITE_DONE (Code 101)
+func (b *Backup) Step(p int) (bool, error) {
 	ret := C.sqlite3_backup_step(b.b, C.int(p))
-	if ret != 0 {
-		return Error{Code: ErrNo(ret)}
+	if ret == 101 {
+		return true, nil
+	} else if ret != 0 {
+		return false, Error{Code: ErrNo(ret)}
 	}
-	return nil
+	return false, nil
 }
 
 func (b *Backup) Remaining() int {

--- a/error.go
+++ b/error.go
@@ -45,7 +45,6 @@ var (
 	ErrNotADB     = ErrNo(26) /* File opened that is not a database file */
 	ErrNotice     = ErrNo(27) /* Notifications from sqlite3_log() */
 	ErrWarning    = ErrNo(28) /* Warnings from sqlite3_log() */
-	ErrDone       = ErrNo(101)
 )
 
 func (err ErrNo) Error() string {


### PR DESCRIPTION
A quick glance at the sqlite3 [api for backup step](http://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep), it shows that `.Step()` may return `SQLITE_DONE`, which under the current scenario will just be an unknown error.

This fixes this and also adds a `IsDone` method to check easily:

```
for {
    err = bk.Step(pagerate)
    if err != nil {
        sqlErr := err.(sqlite3.Error)
        if int(sqlErr.Code) == SQLITE_DONE {
            break
        } else {
            panic(err)
        }
    }
```

Can be rewritten as:

```
for {
    err = bk.Step(pagerate)
    if err != nil {
        if sqlite3.IsDone(err) {
            break
        } else {
            panic(err)
        }
    }
```

This patch doesn't change interface, either.
