### PR TITLE
Update simple.go (very small change)

### DIFF
--- a/_example/simple/simple.go
+++ b/_example/simple/simple.go
@@ -17,13 +17,13 @@ func main() {
 	}
 	defer db.Close()
 
-	sql := `
+	sqlStmt := `
 	create table foo (id integer not null primary key, name text);
 	delete from foo;
 	`
-	_, err = db.Exec(sql)
+	_, err = db.Exec(sqlStmt)
 	if err != nil {
-		log.Printf("%q: %s\n", err, sql)
+		log.Printf("%q: %s\n", err, sqlStmt)
 		return
 	}
 


### PR DESCRIPTION
Renaming the string "sql" into "sqlStmt" in order to prevent mixing with package types & functions sql.\* in future edits or code reuse.
