### PR TITLE
set CFLAGS: -std=gnu99 (fixes SmartOS)

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -6,6 +6,7 @@
 package sqlite3
 
 /*
+#cgo CFLAGS: -std=gnu99
 #include <sqlite3.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes the following error message on SmartOS:

$ go get github.com/mattn/go-sqlite3
In file included from /usr/include/stdio.h:37:0,
                 from go/src/github.com/mattn/go-sqlite3/sqlite3.c:8422:
/opt/local/gcc47/lib/gcc/i386-sun-solaris2.11/4.7.3/include-fixed/sys/feature_tests.h:366:2: error: #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications  require the use of c99"
