### PR TITLE
Return error code of sqlite3_step, not sqlite3_reset

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -441,8 +441,9 @@ func (s *SQLiteStmt) Exec(args []driver.Value) (driver.Result, error) {
 	}
 	rv := C.sqlite3_step(s.s)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
+		err := s.c.lastError()
 		C.sqlite3_reset(s.s)
-		return nil, s.c.lastError()
+		return nil, err
 	}
 
 	res := &SQLiteResult{


### PR DESCRIPTION
Since sqlite3_reset will overwrite the connection-specific last error code, the error code should be collected from sqlite just after the call to sqlite3_step.