### PR TITLE
 optimize create table sql in examples

### DIFF
--- a/_example/simple/simple.go
+++ b/_example/simple/simple.go
@@ -18,7 +18,7 @@ func main() {
 	defer db.Close()
 
 	sqlStmt := `
-	create table foo (id integer not null primary key, name text);
+	create table foo ([id] integer not null primary key, [name] text);
 	delete from foo;
 	`
 	_, err = db.Exec(sqlStmt)


### PR DESCRIPTION
Some times in sqlite, the field may be just an integer.

if we use sql like 

```
create table foo (id integer not null primary key, name text, 1 float);
```
it runs wrong, so a better solution is to use sql like

```
create table foo ([id] integer not null primary key, [name] text, [1] float);
```