### PR TITLE
Optimize queries

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -373,7 +373,7 @@ func (c *SQLiteConn) Prepare(query string) (driver.Stmt, error) {
 		return nil, c.lastError()
 	}
 	var t string
-	if tail != nil && C.strlen(tail) > 0 {
+	if tail != nil && *tail != '\000' {
 		t = strings.TrimSpace(C.GoString(tail))
 	}
 	ss := &SQLiteStmt{c: c, s: s, t: t}


### PR DESCRIPTION
Main change is running three SQLite API functions every time we cross the border to `Exec` a query.

Before:

```
BenchmarkExec           500000     162257 req/s
BenchmarkQuery          100000      60699 req/s
BenchmarkParams         100000      56971 req/s
BenchmarkStmt           200000      98856 req/s
BenchmarkRows             5000       1883 req/s
BenchmarkStmtRows         5000       1926 req/s
PASS
ok      github.com/mattn/go-sqlite3 18.560s
```

After:

```
BenchmarkExec           500000     172340 req/s
BenchmarkQuery          100000      62041 req/s
BenchmarkParams         100000      58299 req/s
BenchmarkStmt           200000     101137 req/s
BenchmarkRows             5000       1922 req/s
BenchmarkStmtRows         5000       1946 req/s
PASS
ok      github.com/mattn/go-sqlite3 18.178s
```

(These are single benchmarks, but the speedup in `BenchmarkExec` is consistent across runs.)