### PR TITLE
Fix for go-sqlite3 truncating 64-bit lastInsertIDs on 32-bit systems

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -48,21 +48,21 @@ _sqlite3_bind_blob(sqlite3_stmt *stmt, int n, void *p, int np) {
 #include <stdint.h>
 
 static int
-_sqlite3_exec(sqlite3* db, const char* pcmd, long* rowid, long* changes)
+_sqlite3_exec(sqlite3* db, const char* pcmd, long long* rowid, long long* changes)
 {
   int rv = sqlite3_exec(db, pcmd, 0, 0, 0);
-  *rowid = (long) sqlite3_last_insert_rowid(db);
-  *changes = (long) sqlite3_changes(db);
+  *rowid = (long long) sqlite3_last_insert_rowid(db);
+  *changes = (long long) sqlite3_changes(db);
   return rv;
 }
 
 static int
-_sqlite3_step(sqlite3_stmt* stmt, long* rowid, long* changes)
+_sqlite3_step(sqlite3_stmt* stmt, long long* rowid, long long* changes)
 {
   int rv = sqlite3_step(stmt);
   sqlite3* db = sqlite3_db_handle(stmt);
-  *rowid = (long) sqlite3_last_insert_rowid(db);
-  *changes = (long) sqlite3_changes(db);
+  *rowid = (long long) sqlite3_last_insert_rowid(db);
+  *changes = (long long) sqlite3_changes(db);
   return rv;
 }
 
@@ -243,7 +243,7 @@ func (c *SQLiteConn) exec(cmd string) (driver.Result, error) {
 	pcmd := C.CString(cmd)
 	defer C.free(unsafe.Pointer(pcmd))
 
-	var rowid, changes C.long
+	var rowid, changes C.longlong
 	rv := C._sqlite3_exec(c.db, pcmd, &rowid, &changes)
 	if rv != C.SQLITE_OK {
 		return nil, c.lastError()
@@ -536,7 +536,7 @@ func (s *SQLiteStmt) Exec(args []driver.Value) (driver.Result, error) {
 		C.sqlite3_clear_bindings(s.s)
 		return nil, err
 	}
-	var rowid, changes C.long
+	var rowid, changes C.longlong
 	rv := C._sqlite3_step(s.s, &rowid, &changes)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
 		err := s.c.lastError()


### PR DESCRIPTION
Currently, when using go-sqlite3 on 32 bit systems, LastInsertId is truncated from 64 bits to 32 bits, before being cast back to 64 bits.

This happens because golang's C.long is implementation dependent, and on 32-bit systems is 32 bits.

I have changed this from C.long to C.longlong.

Go test results:
```
BenchmarkExec           500000     342197 req/s
BenchmarkQuery          200000      88448 req/s
BenchmarkParams         100000      72247 req/s
BenchmarkStmt           200000     106827 req/s
BenchmarkRows             3000       2087 req/s
BenchmarkStmtRows         3000       2144 req/s
PASS
ok      github.com/kiwih/go-sqlite3     31.694s
```