### PR TITLE
Implement support for calling Go functions from SQLite

### DIFF
--- a/_example/go_custom_funcs/main.go
+++ b/_example/go_custom_funcs/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"math"
+	"math/rand"
+
+	sqlite "github.com/mattn/go-sqlite3"
+)
+
+// Computes x^y
+func pow(x, y int64) int64 {
+	return int64(math.Pow(float64(x), float64(y)))
+}
+
+// Computes the bitwise exclusive-or of all its arguments
+func xor(xs ...int64) int64 {
+	var ret int64
+	for _, x := range xs {
+		ret ^= x
+	}
+	return ret
+}
+
+// Returns a random number. It's actually deterministic here because
+// we don't seed the RNG, but it's an example of a non-pure function
+// from SQLite's POV.
+func getrand() int64 {
+	return rand.Int63()
+}
+
+// Computes the standard deviation of a GROUPed BY set of values
+type stddev struct {
+	xs []int64
+	// Running average calculation
+	sum int64
+	n   int64
+}
+
+func newStddev() *stddev { return &stddev{} }
+
+func (s *stddev) Step(x int64) {
+	s.xs = append(s.xs, x)
+	s.sum += x
+	s.n++
+}
+
+func (s *stddev) Done() float64 {
+	mean := float64(s.sum) / float64(s.n)
+	var sqDiff []float64
+	for _, x := range s.xs {
+		sqDiff = append(sqDiff, math.Pow(float64(x)-mean, 2))
+	}
+	var dev float64
+	for _, x := range sqDiff {
+		dev += x
+	}
+	dev /= float64(len(sqDiff))
+	return math.Sqrt(dev)
+}
+
+func main() {
+	sql.Register("sqlite3_custom", &sqlite.SQLiteDriver{
+		ConnectHook: func(conn *sqlite.SQLiteConn) error {
+			if err := conn.RegisterFunc("pow", pow, true); err != nil {
+				return err
+			}
+			if err := conn.RegisterFunc("xor", xor, true); err != nil {
+				return err
+			}
+			if err := conn.RegisterFunc("rand", getrand, false); err != nil {
+				return err
+			}
+			if err := conn.RegisterAggregator("stddev", newStddev, true); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	db, err := sql.Open("sqlite3_custom", ":memory:")
+	if err != nil {
+		log.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	var i int64
+	err = db.QueryRow("SELECT pow(2,3)").Scan(&i)
+	if err != nil {
+		log.Fatal("POW query error:", err)
+	}
+	fmt.Println("pow(2,3) =", i) // 8
+
+	err = db.QueryRow("SELECT xor(1,2,3,4,5,6)").Scan(&i)
+	if err != nil {
+		log.Fatal("XOR query error:", err)
+	}
+	fmt.Println("xor(1,2,3,4,5) =", i) // 7
+
+	err = db.QueryRow("SELECT rand()").Scan(&i)
+	if err != nil {
+		log.Fatal("RAND query error:", err)
+	}
+	fmt.Println("rand() =", i) // pseudorandom
+
+	_, err = db.Exec("create table foo (department integer, profits integer)")
+	if err != nil {
+		log.Fatal("Failed to create table:", err)
+	}
+	_, err = db.Exec("insert into foo values (1, 10), (1, 20), (1, 45), (2, 42), (2, 115)")
+	if err != nil {
+		log.Fatal("Failed to insert records:", err)
+	}
+
+	rows, err := db.Query("select department, stddev(profits) from foo group by department")
+	if err != nil {
+		log.Fatal("STDDEV query error:", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var dept int64
+		var dev float64
+		if err := rows.Scan(&dept, &dev); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("dept=%d stddev=%f\n", dept, dev)
+	}
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/callback.go
+++ b/callback.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package sqlite3
+
+/*
+#include <sqlite3-binding.h>
+*/
+import "C"
+
+import "unsafe"
+
+//export callbackTrampoline
+func callbackTrampoline(ctx *C.sqlite3_context, argc int, argv **C.sqlite3_value) {
+	args := (*[1 << 30]*C.sqlite3_value)(unsafe.Pointer(argv))[:argc:argc]
+	fi := (*functionInfo)(unsafe.Pointer(C.sqlite3_user_data(ctx)))
+	fi.Call(ctx, args)
+}

--- a/callback_test.go
+++ b/callback_test.go
@@ -1,0 +1,97 @@
+package sqlite3
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestCallbackArgCast(t *testing.T) {
+	intConv := callbackSyntheticForTests(reflect.ValueOf(int64(math.MaxInt64)), nil)
+	floatConv := callbackSyntheticForTests(reflect.ValueOf(float64(math.MaxFloat64)), nil)
+	errConv := callbackSyntheticForTests(reflect.Value{}, errors.New("test"))
+
+	tests := []struct {
+		f callbackArgConverter
+		o reflect.Value
+	}{
+		{intConv, reflect.ValueOf(int8(-1))},
+		{intConv, reflect.ValueOf(int16(-1))},
+		{intConv, reflect.ValueOf(int32(-1))},
+		{intConv, reflect.ValueOf(uint8(math.MaxUint8))},
+		{intConv, reflect.ValueOf(uint16(math.MaxUint16))},
+		{intConv, reflect.ValueOf(uint32(math.MaxUint32))},
+		// Special case, int64->uint64 is only 1<<63 - 1, not 1<<64 - 1
+		{intConv, reflect.ValueOf(uint64(math.MaxInt64))},
+		{floatConv, reflect.ValueOf(float32(math.Inf(1)))},
+	}
+
+	for _, test := range tests {
+		conv := callbackArgCast{test.f, test.o.Type()}
+		val, err := conv.Run(nil)
+		if err != nil {
+			t.Errorf("Couldn't convert to %s: %s", test.o.Type(), err)
+		} else if !reflect.DeepEqual(val.Interface(), test.o.Interface()) {
+			t.Errorf("Unexpected result from converting to %s: got %v, want %v", test.o.Type(), val.Interface(), test.o.Interface())
+		}
+	}
+
+	conv := callbackArgCast{errConv, reflect.TypeOf(int8(0))}
+	_, err := conv.Run(nil)
+	if err == nil {
+		t.Errorf("Expected error during callbackArgCast, but got none")
+	}
+}
+
+func TestCallbackConverters(t *testing.T) {
+	tests := []struct {
+		v   interface{}
+		err bool
+	}{
+		// Unfortunately, we can't tell which converter was returned,
+		// but we can at least check which types can be converted.
+		{[]byte{0}, false},
+		{"text", false},
+		{true, false},
+		{int8(0), false},
+		{int16(0), false},
+		{int32(0), false},
+		{int64(0), false},
+		{uint8(0), false},
+		{uint16(0), false},
+		{uint32(0), false},
+		{uint64(0), false},
+		{int(0), false},
+		{uint(0), false},
+		{float64(0), false},
+		{float32(0), false},
+
+		{func() {}, true},
+		{complex64(complex(0, 0)), true},
+		{complex128(complex(0, 0)), true},
+		{struct{}{}, true},
+		{map[string]string{}, true},
+		{[]string{}, true},
+		{(*int8)(nil), true},
+		{make(chan int), true},
+	}
+
+	for _, test := range tests {
+		_, err := callbackArg(reflect.TypeOf(test.v))
+		if test.err && err == nil {
+			t.Errorf("Expected an error when converting %s, got no error", reflect.TypeOf(test.v))
+		} else if !test.err && err != nil {
+			t.Errorf("Expected converter when converting %s, got error: %s", reflect.TypeOf(test.v), err)
+		}
+	}
+
+	for _, test := range tests {
+		_, err := callbackRet(reflect.TypeOf(test.v))
+		if test.err && err == nil {
+			t.Errorf("Expected an error when converting %s, got no error", reflect.TypeOf(test.v))
+		} else if !test.err && err != nil {
+			t.Errorf("Expected converter when converting %s, got error: %s", reflect.TypeOf(test.v), err)
+		}
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -33,7 +33,7 @@ extension for Regexp matcher operation.
     #include <string.h>
     #include <stdio.h>
     #include <sqlite3ext.h>
-    
+
     SQLITE_EXTENSION_INIT1
     static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
       if (argc >= 2) {
@@ -44,7 +44,7 @@ extension for Regexp matcher operation.
         int vec[500];
         int n, rc;
         pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
-        rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500); 
+        rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500);
         if (rc <= 0) {
           sqlite3_result_error(context, errstr, 0);
           return;
@@ -52,7 +52,7 @@ extension for Regexp matcher operation.
         sqlite3_result_int(context, 1);
       }
     }
-    
+
     #ifdef _WIN32
     __declspec(dllexport)
     #endif
@@ -90,6 +90,23 @@ you need to hook ConnectHook and get the SQLiteConn.
 						return nil
 					},
 			})
+
+Go SQlite3 Extensions
+
+If you want to register Go functions as SQLite extension functions,
+call RegisterFunction from ConnectHook.
+
+	regex = func(re, s string) (bool, error) {
+		return regexp.MatchString(re, s)
+	}
+	sql.Register("sqlite3_with_go_func",
+			&sqlite3.SQLiteDriver{
+					ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+						return conn.RegisterFunc("regex", regex, true)
+					},
+			})
+
+See the documentation of RegisterFunc for more details.
 
 */
 package sqlite3

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -232,11 +232,14 @@ func (tx *SQLiteTx) Rollback() error {
 
 // RegisterFunc makes a Go function available as a SQLite function.
 //
-// The function can accept arguments of any real numeric type
-// (i.e. not complex), as well as []byte and string. It must return a
-// value of one of those types, and optionally an error as a second
-// value. Variadic functions are allowed, if the variadic argument is
-// one of the allowed types.
+// The Go function can have arguments of the following types: any
+// numeric type except complex, bool, []byte, string and
+// interface{}. interface{} arguments are given the direct translation
+// of the SQLite data type: int64 for INTEGER, float64 for FLOAT,
+// []byte for BLOB, string for TEXT.
+//
+// The function can additionally be variadic, as long as the type of
+// the variadic argument is one of the above.
 //
 // If pure is true. SQLite will assume that the function's return
 // value depends only on its inputs, and make more aggressive

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -75,6 +75,8 @@ void _sqlite3_result_blob(sqlite3_context* ctx, const void* b, int l) {
 }
 
 void callbackTrampoline(sqlite3_context*, int, sqlite3_value**);
+void stepTrampoline(sqlite3_context*, int, sqlite3_value**);
+void doneTrampoline(sqlite3_context*);
 */
 import "C"
 import (
@@ -127,10 +129,11 @@ type SQLiteDriver struct {
 
 // Conn struct.
 type SQLiteConn struct {
-	db     *C.sqlite3
-	loc    *time.Location
-	txlock string
-	funcs  []*functionInfo
+	db          *C.sqlite3
+	loc         *time.Location
+	txlock      string
+	funcs       []*functionInfo
+	aggregators []*aggInfo
 }
 
 // Tx struct.
@@ -171,49 +174,96 @@ type functionInfo struct {
 	retConverter      callbackRetConverter
 }
 
-func (fi *functionInfo) error(ctx *C.sqlite3_context, err error) {
-	cstr := C.CString(err.Error())
-	defer C.free(unsafe.Pointer(cstr))
-	C.sqlite3_result_error(ctx, cstr, -1)
-}
-
 func (fi *functionInfo) Call(ctx *C.sqlite3_context, argv []*C.sqlite3_value) {
-	var args []reflect.Value
-
-	if len(argv) < len(fi.argConverters) {
-		fi.error(ctx, fmt.Errorf("function requires at least %d arguments", len(fi.argConverters)))
-	}
-
-	for i, arg := range argv[:len(fi.argConverters)] {
-		v, err := fi.argConverters[i](arg)
-		if err != nil {
-			fi.error(ctx, err)
-			return
-		}
-		args = append(args, v)
-	}
-
-	if fi.variadicConverter != nil {
-		for _, arg := range argv[len(fi.argConverters):] {
-			v, err := fi.variadicConverter(arg)
-			if err != nil {
-				fi.error(ctx, err)
-				return
-			}
-			args = append(args, v)
-		}
+	args, err := callbackConvertArgs(argv, fi.argConverters, fi.variadicConverter)
+	if err != nil {
+		callbackError(ctx, err)
+		return
 	}
 
 	ret := fi.f.Call(args)
 
 	if len(ret) == 2 && ret[1].Interface() != nil {
-		fi.error(ctx, ret[1].Interface().(error))
+		callbackError(ctx, ret[1].Interface().(error))
 		return
 	}
 
-	err := fi.retConverter(ctx, ret[0])
+	err = fi.retConverter(ctx, ret[0])
 	if err != nil {
-		fi.error(ctx, err)
+		callbackError(ctx, err)
+		return
+	}
+}
+
+type aggInfo struct {
+	constructor reflect.Value
+
+	// Active aggregator objects for aggregations in flight. The
+	// aggregators are indexed by a counter stored in the aggregation
+	// user data space provided by sqlite.
+	active map[int64]reflect.Value
+	next   int64
+
+	stepArgConverters     []callbackArgConverter
+	stepVariadicConverter callbackArgConverter
+
+	doneRetConverter callbackRetConverter
+}
+
+func (ai *aggInfo) agg(ctx *C.sqlite3_context) (int64, reflect.Value, error) {
+	aggIdx := (*int64)(C.sqlite3_aggregate_context(ctx, C.int(8)))
+	if *aggIdx == 0 {
+		*aggIdx = ai.next
+		ret := ai.constructor.Call(nil)
+		if len(ret) == 2 && ret[1].Interface() != nil {
+			return 0, reflect.Value{}, ret[1].Interface().(error)
+		}
+		if ret[0].IsNil() {
+			return 0, reflect.Value{}, errors.New("aggregator constructor returned nil state")
+		}
+		ai.next++
+		ai.active[*aggIdx] = ret[0]
+	}
+	return *aggIdx, ai.active[*aggIdx], nil
+}
+
+func (ai *aggInfo) Step(ctx *C.sqlite3_context, argv []*C.sqlite3_value) {
+	_, agg, err := ai.agg(ctx)
+	if err != nil {
+		callbackError(ctx, err)
+		return
+	}
+
+	args, err := callbackConvertArgs(argv, ai.stepArgConverters, ai.stepVariadicConverter)
+	if err != nil {
+		callbackError(ctx, err)
+		return
+	}
+
+	ret := agg.MethodByName("Step").Call(args)
+	if len(ret) == 1 && ret[0].Interface() != nil {
+		callbackError(ctx, ret[0].Interface().(error))
+		return
+	}
+}
+
+func (ai *aggInfo) Done(ctx *C.sqlite3_context) {
+	idx, agg, err := ai.agg(ctx)
+	if err != nil {
+		callbackError(ctx, err)
+		return
+	}
+	defer func() { delete(ai.active, idx) }()
+
+	ret := agg.MethodByName("Done").Call(nil)
+	if len(ret) == 2 && ret[1].Interface() != nil {
+		callbackError(ctx, ret[1].Interface().(error))
+		return
+	}
+
+	err = ai.doneRetConverter(ctx, ret[0])
+	if err != nil {
+		callbackError(ctx, err)
 		return
 	}
 }
@@ -244,6 +294,8 @@ func (tx *SQLiteTx) Rollback() error {
 // If pure is true. SQLite will assume that the function's return
 // value depends only on its inputs, and make more aggressive
 // optimizations in its queries.
+//
+// See _example/go_custom_funcs for a detailed example.
 func (c *SQLiteConn) RegisterFunc(name string, impl interface{}, pure bool) error {
 	var fi functionInfo
 	fi.f = reflect.ValueOf(impl)
@@ -298,7 +350,132 @@ func (c *SQLiteConn) RegisterFunc(name string, impl interface{}, pure bool) erro
 	if pure {
 		opts |= C.SQLITE_DETERMINISTIC
 	}
-	rv := C.sqlite3_create_function_v2(c.db, cname, C.int(numArgs), C.int(opts), unsafe.Pointer(&fi), (*[0]byte)(unsafe.Pointer(C.callbackTrampoline)), nil, nil, nil)
+	rv := C.sqlite3_create_function(c.db, cname, C.int(numArgs), C.int(opts), unsafe.Pointer(&fi), (*[0]byte)(unsafe.Pointer(C.callbackTrampoline)), nil, nil)
+	if rv != C.SQLITE_OK {
+		return c.lastError()
+	}
+	return nil
+}
+
+// RegisterAggregator makes a Go type available as a SQLite aggregation function.
+//
+// Because aggregation is incremental, it's implemented in Go with a
+// type that has 2 methods: func Step(values) accumulates one row of
+// data into the accumulator, and func Done() ret finalizes and
+// returns the aggregate value. "values" and "ret" may be any type
+// supported by RegisterFunc.
+//
+// RegisterAggregator takes as implementation a constructor function
+// that constructs an instance of the aggregator type each time an
+// aggregation begins. The constructor must return a pointer to a
+// type, or an interface that implements Step() and Done().
+//
+// The constructor function and the Step/Done methods may optionally
+// return an error in addition to their other return values.
+//
+// See _example/go_custom_funcs for a detailed example.
+func (c *SQLiteConn) RegisterAggregator(name string, impl interface{}, pure bool) error {
+	var ai aggInfo
+	ai.constructor = reflect.ValueOf(impl)
+	t := ai.constructor.Type()
+	if t.Kind() != reflect.Func {
+		return errors.New("non-function passed to RegisterAggregator")
+	}
+	if t.NumOut() != 1 && t.NumOut() != 2 {
+		return errors.New("SQLite aggregator constructors must return 1 or 2 values")
+	}
+	if t.NumOut() == 2 && !t.Out(1).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+		return errors.New("Second return value of SQLite function must be error")
+	}
+	if t.NumIn() != 0 {
+		return errors.New("SQLite aggregator constructors must not have arguments")
+	}
+
+	agg := t.Out(0)
+	switch agg.Kind() {
+	case reflect.Ptr, reflect.Interface:
+	default:
+		return errors.New("SQlite aggregator constructor must return a pointer object")
+	}
+	stepFn, found := agg.MethodByName("Step")
+	if !found {
+		return errors.New("SQlite aggregator doesn't have a Step() function")
+	}
+	step := stepFn.Type
+	if step.NumOut() != 0 && step.NumOut() != 1 {
+		return errors.New("SQlite aggregator Step() function must return 0 or 1 values")
+	}
+	if step.NumOut() == 1 && !step.Out(0).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+		return errors.New("type of SQlite aggregator Step() return value must be error")
+	}
+
+	stepNArgs := step.NumIn()
+	start := 0
+	if agg.Kind() == reflect.Ptr {
+		// Skip over the method receiver
+		stepNArgs--
+		start++
+	}
+	if step.IsVariadic() {
+		stepNArgs--
+	}
+	for i := start; i < start+stepNArgs; i++ {
+		conv, err := callbackArg(step.In(i))
+		if err != nil {
+			return err
+		}
+		ai.stepArgConverters = append(ai.stepArgConverters, conv)
+	}
+	if step.IsVariadic() {
+		conv, err := callbackArg(t.In(start + stepNArgs).Elem())
+		if err != nil {
+			return err
+		}
+		ai.stepVariadicConverter = conv
+		// Pass -1 to sqlite so that it allows any number of
+		// arguments. The call helper verifies that the minimum number
+		// of arguments is present for variadic functions.
+		stepNArgs = -1
+	}
+
+	doneFn, found := agg.MethodByName("Done")
+	if !found {
+		return errors.New("SQlite aggregator doesn't have a Done() function")
+	}
+	done := doneFn.Type
+	doneNArgs := done.NumIn()
+	if agg.Kind() == reflect.Ptr {
+		// Skip over the method receiver
+		doneNArgs--
+	}
+	if doneNArgs != 0 {
+		return errors.New("SQlite aggregator Done() function must have no arguments")
+	}
+	if done.NumOut() != 1 && done.NumOut() != 2 {
+		return errors.New("SQLite aggregator Done() function must return 1 or 2 values")
+	}
+	if done.NumOut() == 2 && !done.Out(1).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+		return errors.New("second return value of SQLite aggregator Done() function must be error")
+	}
+
+	conv, err := callbackRet(done.Out(0))
+	if err != nil {
+		return err
+	}
+	ai.doneRetConverter = conv
+	ai.active = make(map[int64]reflect.Value)
+	ai.next = 1
+
+	// ai must outlast the database connection, or we'll have dangling pointers.
+	c.aggregators = append(c.aggregators, &ai)
+
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	opts := C.SQLITE_UTF8
+	if pure {
+		opts |= C.SQLITE_DETERMINISTIC
+	}
+	rv := C.sqlite3_create_function(c.db, cname, C.int(stepNArgs), C.int(opts), unsafe.Pointer(&ai), nil, (*[0]byte)(unsafe.Pointer(C.stepTrampoline)), (*[0]byte)(unsafe.Pointer(C.doneTrampoline)))
 	if rv != C.SQLITE_OK {
 		return c.lastError()
 	}

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1071,6 +1071,13 @@ func TestFunctionRegistration(t *testing.T) {
 	regex := func(re, s string) (bool, error) {
 		return regexp.MatchString(re, s)
 	}
+	variadic := func(a, b int64, c ...int64) int64 {
+		ret := a + b
+		for _, d := range c {
+			ret += d
+		}
+		return ret
+	}
 
 	sql.Register("sqlite3_FunctionRegistration", &SQLiteDriver{
 		ConnectHook: func(conn *SQLiteConn) error {
@@ -1098,6 +1105,9 @@ func TestFunctionRegistration(t *testing.T) {
 			if err := conn.RegisterFunc("regex", regex, true); err != nil {
 				return err
 			}
+			if err := conn.RegisterFunc("variadic", variadic, true); err != nil {
+				return err
+			}
 			return nil
 		},
 	})
@@ -1121,6 +1131,9 @@ func TestFunctionRegistration(t *testing.T) {
 		{"SELECT not(0)", true},
 		{`SELECT regex("^foo.*", "foobar")`, true},
 		{`SELECT regex("^foo.*", "barfoobar")`, false},
+		{"SELECT variadic(1,2)", int64(3)},
+		{"SELECT variadic(1,2,3,4)", int64(10)},
+		{"SELECT variadic(1,1,1,1,1,1,1,1,1,1)", int64(10)},
 	}
 
 	for _, op := range ops {

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1175,6 +1175,65 @@ func TestFunctionRegistration(t *testing.T) {
 	}
 }
 
+type sumAggregator int64
+
+func (s *sumAggregator) Step(x int64) {
+	*s += sumAggregator(x)
+}
+
+func (s *sumAggregator) Done() int64 {
+	return int64(*s)
+}
+
+func TestAggregatorRegistration(t *testing.T) {
+	customSum := func() *sumAggregator {
+		var ret sumAggregator
+		return &ret
+	}
+
+	sql.Register("sqlite3_AggregatorRegistration", &SQLiteDriver{
+		ConnectHook: func(conn *SQLiteConn) error {
+			if err := conn.RegisterAggregator("customSum", customSum, true); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+	db, err := sql.Open("sqlite3_AggregatorRegistration", ":memory:")
+	if err != nil {
+		t.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("create table foo (department integer, profits integer)")
+	if err != nil {
+		t.Fatal("Failed to create table:", err)
+	}
+
+	_, err = db.Exec("insert into foo values (1, 10), (1, 20), (2, 42)")
+	if err != nil {
+		t.Fatal("Failed to insert records:", err)
+	}
+
+	tests := []struct {
+		dept, sum int64
+	}{
+		{1, 30},
+		{2, 42},
+	}
+
+	for _, test := range tests {
+		var ret int64
+		err = db.QueryRow("select customSum(profits) from foo where department = $1 group by department", test.dept).Scan(&ret)
+		if err != nil {
+			t.Fatal("Query failed:", err)
+		}
+		if ret != test.sum {
+			t.Fatalf("Custom sum returned wrong value, got %d, want %d", ret, test.sum)
+		}
+	}
+}
+
 var customFunctionOnce sync.Once
 
 func BenchmarkCustomFunctions(b *testing.B) {

--- a/sqlite3_test/sqltest.go
+++ b/sqlite3_test/sqltest.go
@@ -318,7 +318,7 @@ func BenchmarkQuery(b *testing.B) {
 		var i int
 		var f float64
 		var s string
-//		var t time.Time
+		//		var t time.Time
 		if err := db.QueryRow("select null, 1, 1.1, 'foo'").Scan(&n, &i, &f, &s); err != nil {
 			panic(err)
 		}
@@ -331,7 +331,7 @@ func BenchmarkParams(b *testing.B) {
 		var i int
 		var f float64
 		var s string
-//		var t time.Time
+		//		var t time.Time
 		if err := db.QueryRow("select ?, ?, ?, ?", nil, 1, 1.1, "foo").Scan(&n, &i, &f, &s); err != nil {
 			panic(err)
 		}
@@ -350,7 +350,7 @@ func BenchmarkStmt(b *testing.B) {
 		var i int
 		var f float64
 		var s string
-//		var t time.Time
+		//		var t time.Time
 		if err := st.QueryRow(nil, 1, 1.1, "foo").Scan(&n, &i, &f, &s); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes #226.

Supports scalar functions and aggregation functions.

I've benchmarked the call stack, and even with the reflection, the performance matches the QueryRow benchmark (18 microseconds per "SELECT custom_func(1,2)").