### PR TITLE
remove dlopen if static_build flag

### DIFF
--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+// +build !sqlite_omit_load_extension
+
+package sqlite3
+
+/*
+#include <sqlite3-binding.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+func (c *SQLiteConn) loadExtensions(extensions []string) error {
+	rv := C.sqlite3_enable_load_extension(c.db, 1)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+
+	for _, extension := range extensions {
+		cext := C.CString(extension)
+		defer C.free(unsafe.Pointer(cext))
+		rv = C.sqlite3_load_extension(c.db, cext, nil, nil)
+		if rv != C.SQLITE_OK {
+			return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+		}
+	}
+
+	rv = C.sqlite3_enable_load_extension(c.db, 0)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+	return nil
+}

--- a/sqlite3_omit_load_extension.go
+++ b/sqlite3_omit_load_extension.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+// +build sqlite_omit_load_extension
+
+package sqlite3
+
+/*
+#cgo CFLAGS: -DSQLITE_OMIT_LOAD_EXTENSION
+*/
+import "C"
+import (
+	"errors"
+)
+
+func (c *SQLiteConn) loadExtensions(extensions []string) error {
+	return errors.New("Extensions have been disabled for static builds")
+}


### PR DESCRIPTION
This patch adds a CFLAG `-DSQLITE_OMIT_LOAD_EXTENSION` to omit dlopen 
if go build flag `static_build` is passed.

we use this flag on docker/docker, but we can change the name or something 
if you prefer something else.

we do not use the extensions and this will remove the dlopen warning 
when we compile static binaries

cc @tianon 