### PR TITLE
Update README. Install go-sqlite3 to avoid builds with gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This package can be installed with the go get command:
 
     go get github.com/mattn/go-sqlite3
     
+_go-sqlite3_ is *cgo* package.
+If you want to build your app using go-sqlite3, you need gcc.
+However, if you install _go-sqlite3_ with `go install github.com/mattn/go-sqlite`, you don't need gcc to build your app anymore.
+    
 Documentation
 -------------
 


### PR DESCRIPTION
I was struggling with the build speeds of using gcc. My editor will compile the code on every save to check for syntax errors. By installing, my app builds fast again.