### PR TITLE
Fix README project address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package can be installed with the go get command:
     
 _go-sqlite3_ is *cgo* package.
 If you want to build your app using go-sqlite3, you need gcc.
-However, if you install _go-sqlite3_ with `go install github.com/mattn/go-sqlite`, you don't need gcc to build your app anymore.
+However, if you install _go-sqlite3_ with `go install github.com/mattn/go-sqlite3`, you don't need gcc to build your app anymore.
     
 Documentation
 -------------


### PR DESCRIPTION
Missing a 3 in the https://github.com/mattn/go-sqlite3 project address.