### PR TITLE
bind: pass &v[0] in direct call to C

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -814,11 +814,11 @@ func (s *SQLiteStmt) bind(args []driver.Value) error {
 		case float64:
 			rv = C.sqlite3_bind_double(s.s, n, C.double(v))
 		case []byte:
-			var p *byte
-			if len(v) > 0 {
-				p = &v[0]
+			if len(v) == 0 {
+				rv = C._sqlite3_bind_blob(s.s, n, nil, 0)
+			} else {
+				rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(len(v)))
 			}
-			rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(p), C.int(len(v)))
 		case time.Time:
 			b := []byte(v.Format(SQLiteTimestampFormats[0]))
 			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))


### PR DESCRIPTION
In Go 1.6, the cgo checking rules are more precise when they see an
address operation as an argument to the C function.  When you pass &v[0]
to a C function, the cgo check just verifies that v itself does not
contain any pointers.  When you write `p := &v[0]` and then pass p to
the C function, the cgo check is conservative: it verifies that the
entire memory block to which p points does not contain any pointers.
When the bind function is called by code that passes a slice that is
part of a larger struct, this means that the cgo check will look at the
entire larger struct, not just the slice.  This can cause a surprising
run time failure.

Avoid this problem by rewriting the code slightly to pass &v[0] in the
call to the C function itself.

In particular this fixes the tests of github.com/jmoiron/sqlx when using
Go 1.6.