### PR TITLE
Fix minor typos in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FAQ
     > You can pass some arguments into the connection string, for example, a URI.
     > See: https://github.com/mattn/go-sqlite3/issues/39
 
-* Do you want cross compiling? mingw on Linux or Mac?
+* Do you want to cross compile? mingw on Linux or Mac?
 
     > See: https://github.com/mattn/go-sqlite3/issues/106
     > See also: http://www.limitlessfx.com/cross-compile-golang-app-for-windows-from-linux.html
@@ -67,7 +67,7 @@ sqlite3-binding.c, sqlite3-binding.h, sqlite3ext.h
 
 The -binding suffix was added to avoid build failures under gccgo.
 
-In this repository, those files are amalgamation code that copied from SQLite3. The license of those codes are depend on the license of SQLite3.
+In this repository, those files are an amalgamation of code that was copied from SQLite3. The license of that code is the same as the license of SQLite3.
 
 Author
 ------

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 /*
 Package sqlite3 provides interface to SQLite3 databases.
 
-This works as driver for database/sql.
+This works as a driver for database/sql.
 
 Installation
 
@@ -9,7 +9,7 @@ Installation
 
 Supported Types
 
-Currently, go-sqlite3 support following data types.
+Currently, go-sqlite3 supports the following data types.
 
     +------------------------------+
     |go        | sqlite3           |
@@ -26,8 +26,8 @@ Currently, go-sqlite3 support following data types.
 
 SQLite3 Extension
 
-You can write your own extension module for sqlite3. For example, below is a
-extension for Regexp matcher operation.
+You can write your own extension module for sqlite3. For example, below is an
+extension for a Regexp matcher operation.
 
     #include <pcre.h>
     #include <string.h>
@@ -63,8 +63,8 @@ extension for Regexp matcher operation.
           (void*)db, regexp_func, NULL, NULL);
     }
 
-It need to build as so/dll shared library. And you need to register
-extension module like below.
+It needs to be built as a so/dll shared library. And you need to register
+the extension module like below.
 
 	sql.Register("sqlite3_with_extensions",
 		&sqlite3.SQLiteDriver{
@@ -79,9 +79,9 @@ Then, you can use this extension.
 
 Connection Hook
 
-You can hook and inject your codes when connection established. database/sql
-doesn't provide the way to get native go-sqlite3 interfaces. So if you want,
-you need to hook ConnectHook and get the SQLiteConn.
+You can hook and inject your code when the connection is established. database/sql
+doesn't provide a way to get native go-sqlite3 interfaces. So if you want,
+you need to set ConnectHook and get the SQLiteConn.
 
 	sql.Register("sqlite3_with_hook_example",
 			&sqlite3.SQLiteDriver{

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -130,7 +130,7 @@ func init() {
 	sql.Register("sqlite3", &SQLiteDriver{})
 }
 
-// Return SQLite library Version information.
+// Version returns SQLite library version information.
 func Version() (libVersion string, libVersionNumber int, sourceId string) {
 	libVersion = C.GoString(C.sqlite3_libversion())
 	libVersionNumber = int(C.sqlite3_libversion_number())
@@ -598,7 +598,7 @@ func errorString(err Error) string {
 }
 
 // Open database and return a new connection.
-// You can specify DSN string with URI filename.
+// You can specify a DSN string using a URI as the filename.
 //   test.db
 //   file:test.db?cache=shared&mode=memory
 //   :memory:
@@ -715,7 +715,7 @@ func (c *SQLiteConn) Close() error {
 	return nil
 }
 
-// Prepare query string. Return a new statement.
+// Prepare the query string. Return a new statement.
 func (c *SQLiteConn) Prepare(query string) (driver.Stmt, error) {
 	pquery := C.CString(query)
 	defer C.free(unsafe.Pointer(pquery))


### PR DESCRIPTION
Thanks very much for go-sqlite-3 -- I used it to build [rqlite](https://github.com/otoolep/rqlite). While reading the docs, I noticed some small typos. Here are the fixes, but feel free to close if you prefer.