### PR TITLE
Fix sqlite "regexp" function name in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -102,7 +102,7 @@ call RegisterFunction from ConnectHook.
 	sql.Register("sqlite3_with_go_func",
 			&sqlite3.SQLiteDriver{
 					ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-						return conn.RegisterFunc("regex", regex, true)
+						return conn.RegisterFunc("regexp", regex, true)
 					},
 			})
 


### PR DESCRIPTION
Just a drive-by typo fix that bit me when I tried to use this example to add support for the REGEXP operator!