### PR TITLE
Expose LoadExtension with entry point

### DIFF
--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -37,3 +37,27 @@ func (c *SQLiteConn) loadExtensions(extensions []string) error {
 	}
 	return nil
 }
+
+func (c *SQLiteConn) LoadExtension(lib string, entry string) error {
+	rv := C.sqlite3_enable_load_extension(c.db, 1)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+
+	clib := C.CString(lib)
+	defer C.free(unsafe.Pointer(clib))
+	centry := C.CString(entry)
+	defer C.free(unsafe.Pointer(centry))
+
+	rv = C.sqlite3_load_extension(c.db, clib, centry, nil)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+
+	rv = C.sqlite3_enable_load_extension(c.db, 0)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Expose sqlite3_load_extension with entry point argument to allow loading extensions where library name does not match entry point name, eg. libspatialite.

Solves #261