### PR TITLE
Fix inconsistent tx state with database/sql.

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -292,6 +292,12 @@ func (ai *aggInfo) Done(ctx *C.sqlite3_context) {
 // Commit transaction.
 func (tx *SQLiteTx) Commit() error {
 	_, err := tx.c.exec("COMMIT")
+	if err != nil && err.(Error).Code == C.SQLITE_BUSY {
+		// sqlite3 will leave the transaction open in this scenario.
+		// However, database/sql considers the transaction complete once we
+		// return from Commit() - we must clean up to honour its semantics.
+		tx.c.exec("ROLLBACK")
+	}
 	return err
 }
 


### PR DESCRIPTION
The semantics of sql.Tx.Commit impose that the transaction is
finished and cleaned up by the time the driver's Commit function
returns. However sqlite3 leaves the transaction open if COMMIT
fails due to an SQLITE_BUSY error, so *we* must clean it up.

Closes #184.