### PR TITLE
Ubuntu 14.04 LTS libsqlite3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 go:
+  - 1.5
+  - 1.6
   - tip
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 script:
-    - $HOME/gopath/bin/goveralls -repotoken 3qJVUE0iQwqnCbmNcDsjYu1nh4J4KIFXx
+  - $HOME/gopath/bin/goveralls 
+  - go test -v . -tags "libsqlite3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
   - go get golang.org/x/tools/cmd/cover
 script:
   - $HOME/gopath/bin/goveralls 
-  - go test -v . -tags "libsqlite3"
+  - go test . -a -tags "libsqlite3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+sudo: required
+dist: trusty
+os:
+  - linux
+  - osx
 language: go
 go:
   - 1.5
   - 1.6
   - tip
 before_install:
+  - ./.travis/install.sh
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 script:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    brew install libsqlite3
+    brew update
+    brew install sqlite3
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    brew install libsqlite3
+fi

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ FAQ
 * Want to build go-sqlite3 with libsqlite3 on OS X.
 
     Install sqlite3 from homebrew: `brew install sqlite3`
+
     Use `go build --tags "libsqlite3 darwin"`
 
 * Want to build go-sqlite3 with icu extension.

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -29,6 +29,10 @@ package sqlite3
 # define SQLITE_OPEN_FULLMUTEX 0
 #endif
 
+#ifndef SQLITE_DETERMINISTIC
+# define SQLITE_DETERMINISTIC 0
+#endif
+
 static int
 _sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zVfs) {
 #ifdef SQLITE_OPEN_URI

--- a/sqlite3_fts3_test.go
+++ b/sqlite3_fts3_test.go
@@ -93,7 +93,10 @@ func TestFTS4(t *testing.T) {
 
 	_, err = db.Exec("DROP TABLE foo")
 	_, err = db.Exec("CREATE VIRTUAL TABLE foo USING fts4(tokenize=unicode61, id INTEGER PRIMARY KEY, value TEXT)")
-	if err != nil {
+	switch {
+	case err != nil && err.Error() == "unknown tokenizer: unicode61":
+		t.Skip("FTS4 not supported")
+	case err != nil:
 		t.Fatal("Failed to create table:", err)
 	}
 


### PR DESCRIPTION
When testing go-sqlite3 with libsqlite3 on Travis-CI in Trusty environment (Ubuntu 14.04.2 LTS) I found out that symbol SQLITE_DETERMINISTIC is not defined in sqlite 3.8.2.

To solve that issue i default SQLITE_DETERMINISTIC to 0 if it is not defined.