### PR TITLE
Build with libsqlite3 on Ubuntu 14.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+sudo: required
+dist: trusty
 go:
   - 1.5
   - 1.6
@@ -7,5 +9,5 @@ before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 script:
-  - $HOME/gopath/bin/goveralls 
+  - $HOME/gopath/bin/goveralls -repotoken 3qJVUE0iQwqnCbmNcDsjYu1nh4J4KIFXx
   - go test -v . -tags "libsqlite3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 go:
+  - 1.5
+  - 1.6
   - tip
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 script:
-    - $HOME/gopath/bin/goveralls -repotoken 3qJVUE0iQwqnCbmNcDsjYu1nh4J4KIFXx
+  - $HOME/gopath/bin/goveralls 
+  - go test -v . -tags "libsqlite3"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ FAQ
 * Want to build go-sqlite3 with libsqlite3 on OS X.
 
     Install sqlite3 from homebrew: `brew install sqlite3`
+
     Use `go build --tags "libsqlite3 darwin"`
 
 * Want to build go-sqlite3 with icu extension.

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -29,6 +29,10 @@ package sqlite3
 # define SQLITE_OPEN_FULLMUTEX 0
 #endif
 
+#ifndef SQLITE_DETERMINISTIC
+# define SQLITE_DETERMINISTIC 0
+#endif
+
 static int
 _sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zVfs) {
 #ifdef SQLITE_OPEN_URI

--- a/sqlite3_fts3_test.go
+++ b/sqlite3_fts3_test.go
@@ -93,7 +93,10 @@ func TestFTS4(t *testing.T) {
 
 	_, err = db.Exec("DROP TABLE foo")
 	_, err = db.Exec("CREATE VIRTUAL TABLE foo USING fts4(tokenize=unicode61, id INTEGER PRIMARY KEY, value TEXT)")
-	if err != nil {
+	switch {
+	case err != nil && err.Error() == "unknown tokenizer: unicode61":
+		t.Skip("FTS4 not supported")
+	case err != nil:
 		t.Fatal("Failed to create table:", err)
 	}
 


### PR DESCRIPTION
* Sets default value of SQLITE_DETERMINISTIC to 0 if undefined.
* Skip FTS4 test if unicode61 tokenizer is unavailable
* Test go-sqlite3 against libsqlite3
* Test go-sqlite3 against golang versions 1.5 / 1.6