### PR TITLE
Make Go 1.7 fail compilation without cgo

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -110,3 +110,5 @@ See the documentation of RegisterFunc for more details.
 
 */
 package sqlite3
+
+import "C"


### PR DESCRIPTION
The package is useless without cgo, but Go 1.7 will happily build it
since doc.go is a pure-Go file, even if CGO_ENABLED=0, like when
cross-compiling.

This is particularly problematic since the package is usually imported
for its side effects, and users would successfully build a broken binary.

Workaround golang/go#16981