### PR TITLE
Added CFLAG config to ignore deprecations

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -10,6 +10,7 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_ENABLE_RTREE -DSQLITE_THREADSAFE
 #cgo CFLAGS: -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4_UNICODE61
 #cgo CFLAGS: -DSQLITE_TRACE_SIZE_LIMIT=15
+#cgo CFLAGS: -Wno-deprecated-declarations -Wno-c99-extensions
 #ifndef USE_LIBSQLITE3
 #include <sqlite3-binding.h>
 #else


### PR DESCRIPTION
Added a CFLAG line to sqlite3.go that prevents the compiler from emitting warnings about deprecated function calls - addresses #332 #328 #311