### PR TITLE
actually link to <sqlite3.h> when -tags libsqlite3

### DIFF
--- a/sqlite3-binding.h
+++ b/sqlite3-binding.h
@@ -30,6 +30,7 @@
 ** the version number) and changes its name to "sqlite3.h" as
 ** part of the build process.
 */
+#ifndef USE_LIBSQLITE3
 #ifndef SQLITE3_H
 #define SQLITE3_H
 #include <stdarg.h>     /* Needed for the definition of va_list */
@@ -10338,5 +10339,9 @@ struct fts5_api {
 #endif
 
 #endif /* _FTS5_H */
+#else // USE_LIBSQLITE3
+// If users really want to link against the system sqlite3 we
+// need to make this file a noop.
+#endif
 
 /******** End of fts5.h *********/

--- a/sqlite3ext.h
+++ b/sqlite3ext.h
@@ -1,3 +1,4 @@
+#ifndef USE_LIBSQLITE3
 /*
 ** 2006 June 7
 **
@@ -12,7 +13,7 @@
 ** This header file defines the SQLite interface for use by
 ** shared libraries that want to be imported as extensions into
 ** an SQLite instance.  Shared libraries that intend to be loaded
-** as extensions by SQLite should #include this file instead of 
+** as extensions by SQLite should #include this file instead of
 ** sqlite3.h.
 */
 #ifndef SQLITE3EXT_H
@@ -543,14 +544,14 @@ typedef int (*sqlite3_loadext_entry)(
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)
-  /* This case when the file really is being compiled as a loadable 
+  /* This case when the file really is being compiled as a loadable
   ** extension */
 # define SQLITE_EXTENSION_INIT1     const sqlite3_api_routines *sqlite3_api=0;
 # define SQLITE_EXTENSION_INIT2(v)  sqlite3_api=v;
 # define SQLITE_EXTENSION_INIT3     \
     extern const sqlite3_api_routines *sqlite3_api;
 #else
-  /* This case when the file is being statically linked into the 
+  /* This case when the file is being statically linked into the
   ** application */
 # define SQLITE_EXTENSION_INIT1     /*no-op*/
 # define SQLITE_EXTENSION_INIT2(v)  (void)v; /* unused parameter */
@@ -558,3 +559,7 @@ typedef int (*sqlite3_loadext_entry)(
 #endif
 
 #endif /* SQLITE3EXT_H */
+#else // USE_LIBSQLITE3
+ // If users really want to link against the system sqlite3 we
+// need to make this file a noop.
+ #endif

--- a/tool/upgrade.go
+++ b/tool/upgrade.go
@@ -37,18 +37,21 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer resp.Body.Close()
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		resp.Body.Close()
 		log.Fatal(err)
 	}
 
 	fmt.Printf("extracting %v\n", path.Base(url))
 	r, err := zip.NewReader(bytes.NewReader(b), resp.ContentLength)
 	if err != nil {
+		resp.Body.Close()
 		log.Fatal(err)
 	}
+	resp.Body.Close()
+
 	for _, zf := range r.File {
 		var f *os.File
 		switch path.Base(zf.Name) {
@@ -68,11 +71,27 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		_, err = io.Copy(f, zr)
-		f.Close()
+
+		_, err = io.WriteString(f, "#ifndef USE_LIBSQLITE3\n")
 		if err != nil {
+			zr.Close()
+			f.Close()
 			log.Fatal(err)
 		}
+		_, err = io.Copy(f, zr)
+		if err != nil {
+			zr.Close()
+			f.Close()
+			log.Fatal(err)
+		}
+		_, err = io.WriteString(f, "#else // USE_LIBSQLITE3\n // If users really want to link against the system sqlite3 we\n// need to make this file a noop.\n #endif")
+		if err != nil {
+			zr.Close()
+			f.Close()
+			log.Fatal(err)
+		}
+		zr.Close()
+		f.Close()
 		fmt.Printf("extracted %v\n", filepath.Base(f.Name()))
 	}
 }


### PR DESCRIPTION
Building with -tags libsqlite3 used the sqlite3.h from the system but the go
compiler will compile all *.{c,h} files in the same direcory:

	"When the Go tool sees that one or more Go files use the special import
	"C", it will look for other non-Go files in the directory and compile
	them as part of the Go package. Any .c, .s, or .S files will be compiled
	with the C compiler." (https://golang.org/cmd/cgo/)

So if users actually want to link against the system sqlite3 we should make
sqlite3-binding.* a noop.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

Closes #330.

After the patch:

1. linking against system `sqlite3`:
```
chb@conventiont|~/source/go/src/github.com/mattn/go-sqlite3|2016-10-17/fix_libsqlite3_build>
> go build -tags libsqlite3 _example/simple/simple.go
chb@conventiont|~/source/go/src/github.com/mattn/go-sqlite3|2016-10-17/fix_libsqlite3_build %>
> ldd simple | grep sqlite
        libsqlite3.so.0 => /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007f860d0a4000)
```

2. using vendored `sqlite3`:
```
chb@conventiont|~/source/go/src/github.com/mattn/go-sqlite3|2016-10-17/fix_libsqlite3_build %>
> go build _example/simple/simple.go
chb@conventiont|~/source/go/src/github.com/mattn/go-sqlite3|2016-10-17/fix_libsqlite3_build %>
> ldd simple | grep sqlite
```

