### PR TITLE
Removing an unused C import to allow for "buildable" go files. Fixes …

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -110,5 +110,3 @@ See the documentation of RegisterFunc for more details.
 
 */
 package sqlite3
-
-import "C"


### PR DESCRIPTION
…https://github.com/mattn/go-sqlite3/issues/374