### PR TITLE
use for Go 1.8 "context" standard package, not "golang.org/x/net/cont…

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -116,7 +116,10 @@ import (
 	"time"
 	"unsafe"
 
-	"golang.org/x/net/context"
+	/// before Go 1.7, contexts used to be in "golang.org/x/net/context"
+
+	/// but in Go 1.7 and Go 1.8, they are provided by the standard library
+	"context"
 )
 
 // SQLiteTimestampFormats is timestamp formats understood by both this module


### PR DESCRIPTION
Go 1.8 (& probably Go 1.7) has a standard internal `"context"` package which should be imported (in  file `sqlite3.go` in place of `"golang.org/x/net/context"` external package. 