### PR TITLE
Don't convert Unix times to nanoseconds when querying datetime fields…

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -961,10 +961,11 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 				// large to be a reasonable timestamp in seconds.
 				if val > 1e12 || val < -1e12 {
 					val *= int64(time.Millisecond) // convert ms to nsec
+					t = time.Unix(0, val)
 				} else {
-					val *= int64(time.Second) // convert sec to nsec
+					t = time.Unix(val, 0)
 				}
-				t = time.Unix(0, val).UTC()
+				t = t.UTC()
 				if rc.s.c.loc != nil {
 					t = t.In(rc.s.c.loc)
 				}

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -403,6 +403,7 @@ func TestTimestamp(t *testing.T) {
 	}{
 		{"nonsense", time.Time{}},
 		{"0000-00-00 00:00:00", time.Time{}},
+		{time.Time{}.Unix(), time.Time{}},
 		{timestamp1, timestamp1},
 		{timestamp2.Unix(), timestamp2.Truncate(time.Second)},
 		{timestamp2.UnixNano() / int64(time.Millisecond), timestamp2.Truncate(time.Millisecond)},


### PR DESCRIPTION
…. Fixes #430.