### PR TITLE
Support sqlite3_limit to get/set the value of run-time limits

### DIFF
--- a/_example/limit/limit.go
+++ b/_example/limit/limit.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+func createBulkInsertQuery(n int, start int) (query string, args []interface{}) {
+	values := make([]string, n)
+	args = make([]interface{}, n*2)
+	pos := 0
+	for i := 0; i < n; i++ {
+		values[i] = "(?, ?)"
+		args[pos] = start + i
+		args[pos+1] = fmt.Sprintf("こんにちわ世界%03d", i)
+		pos += 2
+	}
+	query = fmt.Sprintf(
+		"insert into foo(id, name) values %s",
+		strings.Join(values, ", "),
+	)
+	return
+}
+
+func bukInsert(db *sql.DB, query string, args []interface{}) (err error) {
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		return
+	}
+
+	_, err = stmt.Exec(args...)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func main() {
+	var sqlite3conn *sqlite3.SQLiteConn
+	sql.Register("sqlite3_with_limit", &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			sqlite3conn = conn
+			return nil
+		},
+	})
+
+	os.Remove("./foo.db")
+	db, err := sql.Open("sqlite3_with_limit", "./foo.db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	sqlStmt := `
+	create table foo (id integer not null primary key, name text);
+	delete from foo;
+	`
+	_, err = db.Exec(sqlStmt)
+	if err != nil {
+		log.Printf("%q: %s\n", err, sqlStmt)
+		return
+	}
+
+	if sqlite3conn == nil {
+		log.Fatal("not set sqlite3 connection")
+	}
+
+	limitVariableNumber := sqlite3conn.GetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
+	log.Printf("default SQLITE_LIMIT_VARIABLE_NUMBER: %d", limitVariableNumber)
+
+	num := 400
+	query, args := createBulkInsertQuery(num, 0)
+	err = bukInsert(db, query, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	smallLimitVariableNumber := 100
+	sqlite3conn.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, smallLimitVariableNumber)
+
+	limitVariableNumber = sqlite3conn.GetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
+	log.Printf("updated SQLITE_LIMIT_VARIABLE_NUMBER: %d", limitVariableNumber)
+
+	query, args = createBulkInsertQuery(num, num)
+	err = bukInsert(db, query, args)
+	if err != nil {
+		if err != nil {
+			log.Printf("expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: %v", err)
+		}
+	}
+
+	bigLimitVariableNumber := 999999
+	sqlite3conn.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, bigLimitVariableNumber)
+	limitVariableNumber = sqlite3conn.GetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER)
+	log.Printf("set SQLITE_LIMIT_VARIABLE_NUMBER: %d", bigLimitVariableNumber)
+	log.Printf("updated SQLITE_LIMIT_VARIABLE_NUMBER: %d", limitVariableNumber)
+
+	query, args = createBulkInsertQuery(500, num+num)
+	err = bukInsert(db, query, args)
+	if err != nil {
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	log.Println("no error if SQLITE_LIMIT_VARIABLE_NUMBER > 999")
+}

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -120,6 +120,8 @@ void updateHookTrampoline(void*, int, char*, char*, sqlite3_int64);
 # define SQLITE_LIMIT_VARIABLE_NUMBER           9
 # define SQLITE_LIMIT_TRIGGER_DEPTH            10
 # define SQLITE_LIMIT_WORKER_THREADS           11
+# else
+# define SQLITE_LIMIT_WORKER_THREADS           11
 #endif
 
 static int _sqlite3_limit(sqlite3* db, int limitId, int newLimit) {

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -827,6 +827,36 @@ func (c *SQLiteConn) prepare(ctx context.Context, query string) (driver.Stmt, er
 	return ss, nil
 }
 
+// Run-Time Limit Categories.
+// See: http://www.sqlite.org/c3ref/c_limit_attached.html
+const (
+	SQLITE_LIMIT_LENGTH              = C.SQLITE_LIMIT_LENGTH
+	SQLITE_LIMIT_SQL_LENGTH          = C.SQLITE_LIMIT_SQL_LENGTH
+	SQLITE_LIMIT_COLUMN              = C.SQLITE_LIMIT_COLUMN
+	SQLITE_LIMIT_EXPR_DEPTH          = C.SQLITE_LIMIT_EXPR_DEPTH
+	SQLITE_LIMIT_COMPOUND_SELECT     = C.SQLITE_LIMIT_COMPOUND_SELECT
+	SQLITE_LIMIT_VDBE_OP             = C.SQLITE_LIMIT_VDBE_OP
+	SQLITE_LIMIT_FUNCTION_ARG        = C.SQLITE_LIMIT_FUNCTION_ARG
+	SQLITE_LIMIT_ATTACHED            = C.SQLITE_LIMIT_ATTACHED
+	SQLITE_LIMIT_LIKE_PATTERN_LENGTH = C.SQLITE_LIMIT_LIKE_PATTERN_LENGTH
+	SQLITE_LIMIT_VARIABLE_NUMBER     = C.SQLITE_LIMIT_VARIABLE_NUMBER
+	SQLITE_LIMIT_TRIGGER_DEPTH       = C.SQLITE_LIMIT_TRIGGER_DEPTH
+	SQLITE_LIMIT_WORKER_THREADS      = C.SQLITE_LIMIT_WORKER_THREADS
+)
+
+// GetLimit returns the current value of a run-time limit.
+// See: sqlite3_limit, http://www.sqlite.org/c3ref/limit.html
+func (c *SQLiteConn) GetLimit(id int) int {
+	return int(C.sqlite3_limit(c.db, C.int(id), -1))
+}
+
+// SetLimit changes the value of a run-time limits.
+// Then this method returns the prior value of the limit.
+// See: sqlite3_limit, http://www.sqlite.org/c3ref/limit.html
+func (c *SQLiteConn) SetLimit(id int, newVal int) int {
+	return int(C.sqlite3_limit(c.db, C.int(id), C.int(newVal)))
+}
+
 // Close the statement.
 func (s *SQLiteStmt) Close() error {
 	s.mu.Lock()

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -105,6 +105,30 @@ int compareTrampoline(void*, int, char*, int, char*);
 int commitHookTrampoline(void*);
 void rollbackHookTrampoline(void*);
 void updateHookTrampoline(void*, int, char*, char*, sqlite3_int64);
+
+#ifdef SQLITE_LIMIT_WORKER_THREADS
+# define _SQLITE_HAS_LIMIT
+# define SQLITE_LIMIT_LENGTH                    0
+# define SQLITE_LIMIT_SQL_LENGTH                1
+# define SQLITE_LIMIT_COLUMN                    2
+# define SQLITE_LIMIT_EXPR_DEPTH                3
+# define SQLITE_LIMIT_COMPOUND_SELECT           4
+# define SQLITE_LIMIT_VDBE_OP                   5
+# define SQLITE_LIMIT_FUNCTION_ARG              6
+# define SQLITE_LIMIT_ATTACHED                  7
+# define SQLITE_LIMIT_LIKE_PATTERN_LENGTH       8
+# define SQLITE_LIMIT_VARIABLE_NUMBER           9
+# define SQLITE_LIMIT_TRIGGER_DEPTH            10
+# define SQLITE_LIMIT_WORKER_THREADS           11
+#endif
+
+static int _sqlite3_limit(sqlite3* db, int limitId, int newLimit) {
+#ifndef _SQLITE_HAS_LIMIT
+  return -1;
+#else
+  return sqlite3_limit(db, limitId, newLimit);
+#endif
+}
 */
 import "C"
 import (
@@ -847,14 +871,14 @@ const (
 // GetLimit returns the current value of a run-time limit.
 // See: sqlite3_limit, http://www.sqlite.org/c3ref/limit.html
 func (c *SQLiteConn) GetLimit(id int) int {
-	return int(C.sqlite3_limit(c.db, C.int(id), -1))
+	return int(C._sqlite3_limit(c.db, C.int(id), -1))
 }
 
 // SetLimit changes the value of a run-time limits.
 // Then this method returns the prior value of the limit.
 // See: sqlite3_limit, http://www.sqlite.org/c3ref/limit.html
 func (c *SQLiteConn) SetLimit(id int, newVal int) int {
-	return int(C.sqlite3_limit(c.db, C.int(id), C.int(newVal)))
+	return int(C._sqlite3_limit(c.db, C.int(id), C.int(newVal)))
 }
 
 // Close the statement.


### PR DESCRIPTION
SQLite has a C interface to get/set the value of run-time limits.

```c
int sqlite3_limit(sqlite3*, int id, int newVal);
```

* http://www.sqlite.org/c3ref/limit.html
* http://www.sqlite.org/c3ref/c_limit_attached.html

It's useful to be able to change the value depends on application needs. For example, sqlite3 may occur an error when bulk-insert is involved.

```
too many SQL variables
```

I added an example code in *_example/limit/limit.go* to show and avoid this error.

```bash
$ go build _example/limit/limit.go && ./limit
2017/07/17 21:45:17 default SQLITE_LIMIT_VARIABLE_NUMBER: 999
2017/07/17 21:45:17 updated SQLITE_LIMIT_VARIABLE_NUMBER: 100
2017/07/17 21:45:17 expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: too many SQL variables
2017/07/17 21:45:17 set SQLITE_LIMIT_VARIABLE_NUMBER: 999999
2017/07/17 21:45:17 updated SQLITE_LIMIT_VARIABLE_NUMBER: 999
2017/07/17 21:45:17 too many SQL variables
```

Oops, *SQLITE_LIMIT_VARIABLE_NUMBER* is **999** even if *sqlite3_limit()* sets **999999**.

```go
bigLimitVariableNumber := 999999
sqlite3conn.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, bigLimitVariableNumber)
```

Because, *sqlite3-binding.c* has a *SQLITE_MAX_VARIABLE_NUMBER*.

```c
/*
** The maximum value of a ?nnn wildcard that the parser will accept.
*/
#ifndef SQLITE_MAX_VARIABLE_NUMBER
# define SQLITE_MAX_VARIABLE_NUMBER 999
#endif
```

As a workaround, it works to set *CGO_CFLAGS*, but I'm not sure this way is appropriate to change max value. Let me know if you have a better way.

```bash
$ export CGO_CFLAGS='-DSQLITE_MAX_VARIABLE_NUMBER=999999'
$ go build _example/limit/limit.go && ./limit
2017/07/17 21:45:55 default SQLITE_LIMIT_VARIABLE_NUMBER: 999999
2017/07/17 21:45:55 updated SQLITE_LIMIT_VARIABLE_NUMBER: 100
2017/07/17 21:45:55 expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: too many SQL variables
2017/07/17 21:45:55 set SQLITE_LIMIT_VARIABLE_NUMBER: 999999
2017/07/17 21:45:55 updated SQLITE_LIMIT_VARIABLE_NUMBER: 999999
2017/07/17 21:45:55 no error if SQLITE_LIMIT_VARIABLE_NUMBER > 999
```

