### PR TITLE
Updated "context" import since it has become a standard library 

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -108,6 +108,7 @@ void updateHookTrampoline(void*, int, char*, char*, sqlite3_int64);
 */
 import "C"
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -121,8 +122,6 @@ import (
 	"sync"
 	"time"
 	"unsafe"
-
-	"golang.org/x/net/context"
 )
 
 // SQLiteTimestampFormats is timestamp formats understood by both this module


### PR DESCRIPTION
After "go 1.7", "context" has become a standard library
Please see: https://golang.org/doc/go1.7#context