### PR TITLE
add a case in Next scan to fix issue #190 and issue #316

### DIFF
--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1111,7 +1111,7 @@ func TestDateTimeNow(t *testing.T) {
 	defer db.Close()
 
 	var d time.Time
-	err = db.QueryRow("SELECT datetime('now')").Scan(TimeStamp{&d})
+	err = db.QueryRow("SELECT datetime('now')").Scan(&d)
 	if err != nil {
 		t.Fatal("Failed to scan datetime:", err)
 	}


### PR DESCRIPTION
I get a same error as in #190 and #316 when I  select a nullable datetime typed column `created_at` in one table:

```sql
SELECT created_at FROM users;
```
then  I use `COALESCE` and `CAST` to give it a default value and cast it as text:

```sql
SELECT cast(coalesce(created_at, '2017-10-16T08:23:19.120Z') as text) as created_at FROM users;
```
and I get the same error.

So I add a case to the `Next()` scan to give datetime typed column a chance to be parsed. After that issue #190/#316 and my problem are all fixed. 

I'm not sure if this's the right approach to the problem, here's twice benchmark results run on my computer:

1. current master version's:
```bash
 ~/go/src/github.com/mattn/go-sqlite3 (master) $ go test
BenchmarkExec           200000     151258 req/s
BenchmarkQuery          100000      60628 req/s
BenchmarkParams         100000      55500 req/s
BenchmarkStmt           100000      74674 req/s
BenchmarkRows             2000       1995 req/s
BenchmarkStmtRows         3000       2041 req/s
PASS
ok  	github.com/mattn/go-sqlite3	22.608s
 ~/go/src/github.com/mattn/go-sqlite3 (master) $ go test
BenchmarkExec           200000     134008 req/s
BenchmarkQuery          100000      55242 req/s
BenchmarkParams         100000      56315 req/s
BenchmarkStmt           100000      74565 req/s
BenchmarkRows             3000       2034 req/s
BenchmarkStmtRows         3000       2033 req/s
PASS
ok  	github.com/mattn/go-sqlite3	23.432s
```

2. the version of this pull request:

```bash
~/go/src/github.com/goonr/go-sqlite3 (master) $ go test
BenchmarkExec           200000     127702 req/s
BenchmarkQuery          100000      57204 req/s
BenchmarkParams         100000      48265 req/s
BenchmarkStmt           100000      73005 req/s
BenchmarkRows             3000       1994 req/s
BenchmarkStmtRows         3000       2034 req/s
PASS
ok  	github.com/goonr/go-sqlite3	23.628s
~/go/src/github.com/goonr/go-sqlite3 (master) $ go test
BenchmarkExec           200000     147327 req/s
BenchmarkQuery          100000      52995 req/s
BenchmarkParams         100000      42885 req/s
BenchmarkStmt           100000      64088 req/s
BenchmarkRows             2000       1990 req/s
BenchmarkStmtRows         3000       2054 req/s
PASS
ok  	github.com/goonr/go-sqlite3	23.691s
```

Thanks~