### PR TITLE
WIP: add basic sqlite command interpreter

### DIFF
--- a/cmd/go-sqlite3/main.go
+++ b/cmd/go-sqlite3/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("not enough arguments")
+	}
+	path := os.Args[1]
+	query := os.Args[2]
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	runQuery(db, query)
+}
+
+func runQuery(db *sql.DB, query string) (err error) {
+	rows, err := db.Query(query)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	cols, err := rows.ColumnTypes()
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	// http://go-database-sql.org/varcols.html
+	vals := make([]interface{}, len(cols))
+	for i, types := range cols {
+		vals[i] = new(sql.RawBytes)
+		fmt.Printf("%-50s\t", types.Name())
+		/* debugging...
+		        length, ok := types.Length()
+				if !ok {
+					length = 0
+				}
+				fmt.Printf("%s[%s]\t", types.DatabaseTypeName(), length)
+		*/
+	}
+	fmt.Printf("\n")
+	for rows.Next() {
+		if err := rows.Scan(vals...); err != nil {
+			log.Println(err)
+			return err
+		}
+		// Now you can check each element of vals for nil-ness,
+		// and you can use type introspection and type assertions
+		// to fetch the column into a typed variable.
+		for i, _ := range vals {
+			if vals[i] == nil {
+				fmt.Printf("%-50s\t", "NULL")
+			} else {
+				fmt.Printf("%-50s\t", vals[i])
+			}
+		}
+		fmt.Printf("\n")
+	}
+	if err := rows.Err(); err != nil {
+		log.Println(err)
+	}
+	return err
+}

--- a/cmd/go-sqlite3/main.go
+++ b/cmd/go-sqlite3/main.go
@@ -1,25 +1,46 @@
 package main
 
 import (
+	"bufio"
 	"database/sql"
 	"fmt"
 	_ "github.com/mattn/go-sqlite3"
 	"log"
 	"os"
+	"strings"
 )
 
 func main() {
+	log.Printf("args: %d\n", len(os.Args))
 	if len(os.Args) < 2 {
 		log.Fatal("not enough arguments")
 	}
 	path := os.Args[1]
-	query := os.Args[2]
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-	runQuery(db, query)
+	if len(os.Args) < 3 {
+		dumbShell(db)
+	} else {
+		query := os.Args[2]
+		runQuery(db, query)
+	}
+}
+
+func dumbShell(db *sql.DB) {
+	for {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("sql> ")
+		var query string
+		query, _ = reader.ReadString('\n')
+		//fmt.Println(query)
+		query = strings.TrimSpace(query)
+		if len(query) > 0 {
+			runQuery(db, query)
+		}
+	}
 }
 
 func runQuery(db *sql.DB, query string) (err error) {


### PR DESCRIPTION
While sqlite obviously ships its own commandline interface to operate
on databases, it is not always as widely available as one would
expect. For example, I'm working on an embeded device here that runs a
custom Linux distribution, and sqlite is not shipped with the
distro. Deploying a binary of sqlite fails because it depends on
shared libraries, and going down that rabbit hole is a problem that
can be pretty hairy to solve. And compiling sqlite itself statically
isn't quite workable for all sorts of reasons.

Which brings us to this project: golang compiles statically by
default, and I've successfully deployed a small program using this
library on the embedded device without problems. But to do some more
debugging, I now need an actual SQL shell to run commands.

So I wrote this small command that creates a go-sqlite3 binary which
behaves somewhat like the normal sqlite command. It's way more limited
of course: output isn't really formatted correctly into tables and
only crude functionality is implemented. But databases can be read
with SELECT queries, which can be passed on the commandline or through
a crude shell-like commandline prompt.

This is similiar to the commands in _example but is actually usable,
so I have thrown it in the standard `cmd` subdirectory, in the hope it
can be installed directly.

Still missing:

 - [ ] commandline history. can be implemented with [ishell] or
   [readline] or [GNU readline]
   
 - [ ] table formatting. possibly: [tabwriter], [tablewriter],
   [columnize], [cli-table]

[ishell]: https://github.com/abiosoft/ishell
[readline]: https://github.com/chzyer/readline
[GNU readline]: https://github.com/bobappleyard/readline
[tabwriter]: https://golang.org/pkg/text/tabwriter/
[tablewriter]: https://github.com/olekukonko/tablewriter
[columnize]: https://github.com/ryanuber/columnize
[cli-table]: https://github.com/geckoboard/cli-table