### PR TITLE
Adds GetFilename (sqlite3_db_filename) to SqliteConn

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1018,6 +1018,17 @@ const (
 	SQLITE_LIMIT_WORKER_THREADS      = C.SQLITE_LIMIT_WORKER_THREADS
 )
 
+// GetFilename returns the absolute path to the file containing
+// the requested schema. When passed an empty string, it will
+// instead use the database's default schema: "main".
+// See: sqlite3_db_filename, https://www.sqlite.org/c3ref/db_filename.html
+func (c *SQLiteConn) GetFilename(schemaName string) string {
+	if schemaName == "" {
+		schemaName = "main"
+	}
+	return C.GoString(C.sqlite3_db_filename(c.db, C.CString(schemaName)))
+}
+
 // GetLimit returns the current value of a run-time limit.
 // See: sqlite3_limit, http://www.sqlite.org/c3ref/limit.html
 func (c *SQLiteConn) GetLimit(id int) int {


### PR DESCRIPTION
Enables a user with a `SqliteConn` reference to find out, among other things, what it's a connection to without having to manually track connection handles. Also very handy for diagnostic purposes.