### PR TITLE
Add nil check in bind and a test

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1511,11 +1511,15 @@ func (s *SQLiteStmt) bind(args []namedValue) error {
 		case float64:
 			rv = C.sqlite3_bind_double(s.s, n, C.double(v))
 		case []byte:
-			ln := len(v)
-			if ln == 0 {
-				v = placeHolder
+			if v == nil {
+				rv = C.sqlite3_bind_null(s.s, n)
+			} else {
+				ln := len(v)
+				if ln == 0 {
+					v = placeHolder
+				}
+				rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
 			}
-			rv = C._sqlite3_bind_blob(s.s, n, unsafe.Pointer(&v[0]), C.int(ln))
 		case time.Time:
 			b := []byte(v.Format(SQLiteTimestampFormats[0]))
 			rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1593,6 +1593,10 @@ func TestInsertNilByteSlice(t *testing.T) {
 	if _, err := db.Exec("insert into blob_not_null (b) values (?)", nilSlice); err == nil {
 		t.Fatal("didn't expect INSERT to 'not null' column with a nil []byte slice to work")
 	}
+	zeroLenSlice := []byte{}
+	if _, err := db.Exec("insert into blob_not_null (b) values (?)", zeroLenSlice); err != nil {
+		t.Fatal("failed to insert zero-length slice")
+	}
 }
 
 var customFunctionOnce sync.Once

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1580,6 +1580,21 @@ func TestNilAndEmptyBytes(t *testing.T) {
 	}
 }
 
+func TestInsertNilByteSlice(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("create table blob_not_null (b blob not null)"); err != nil {
+		t.Fatal(err)
+	}
+	var nilSlice []byte
+	if _, err := db.Exec("insert into blob_not_null (b) values (?)", nilSlice); err == nil {
+		t.Fatal("didn't expect INSERT to 'not null' column with a nil []byte slice to work")
+	}
+}
+
 var customFunctionOnce sync.Once
 
 func BenchmarkCustomFunctions(b *testing.B) {


### PR DESCRIPTION
This is the fix for #542. 

There are extensive tests in the existing `TestNilAndEmptyBytes`, but we cannot test the change in there because of how `sqlite3_column_blob()` works: _"The return value from sqlite3_column_blob() for a zero-length BLOB is a NULL pointer."_ -> this means that both `NULL` and `zero-length blob` map to a `nil` byte slice. So... I ended up adding a separate test `TestInsertNilByteSlice` to check that storing a nil byte slice is now storing a `NULL`.