### PR TITLE
Update Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ env:
   matrix:
     - GOTAGS=
     - GOTAGS=libsqlite3
-    - GOTAGS="sqlite_allow_uri_authority sqlite_app_armor sqlite_foreign_keys sqlite_fts5 sqlite_icu sqlite_introspect sqlite_json sqlite_secure_delete sqlite_see sqlite_stat4 sqlite_trace sqlite_userauth"
+    - GOTAGS="sqlite_allow_uri_authority sqlite_app_armor sqlite_foreign_keys sqlite_fts5 sqlite_icu sqlite_introspect sqlite_json sqlite_secure_delete sqlite_see sqlite_stat4 sqlite_trace sqlite_userauth sqlite_vacuum_incr sqlite_vtable"
     - GOTAGS=sqlite_vacuum_full
-    - GOTAGS=sqlite_vacuum_incr
-    - GOTAGS=sqlite_vtable
 
 go:
   - 1.9.x


### PR DESCRIPTION
Moved `sqlite_vacuum_incr` and `sqlite_vtable` to module job.

* `sqlite_vacuum_incr` will only store the required auto vacuum information into the database page, and not preform an vacuum therefor this can be added easily to the module job.
* `sqlite_vtable` does not require an separate job because user will include the tag in combination with others.

This change will approximately save 24+ minutes on Travis-CI.