### PR TITLE
Update go doc comments to refer to correct interfaces.

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -205,13 +205,13 @@ const (
 	SQLITE_UPDATE = C.SQLITE_UPDATE
 )
 
-// SQLiteDriver implement sql.Driver.
+// SQLiteDriver implements driver.Driver.
 type SQLiteDriver struct {
 	Extensions  []string
 	ConnectHook func(*SQLiteConn) error
 }
 
-// SQLiteConn implement sql.Conn.
+// SQLiteConn implements driver.Conn.
 type SQLiteConn struct {
 	mu          sync.Mutex
 	db          *C.sqlite3
@@ -221,12 +221,12 @@ type SQLiteConn struct {
 	aggregators []*aggInfo
 }
 
-// SQLiteTx implemen sql.Tx.
+// SQLiteTx implements driver.Tx.
 type SQLiteTx struct {
 	c *SQLiteConn
 }
 
-// SQLiteStmt implement sql.Stmt.
+// SQLiteStmt implements driver.Stmt.
 type SQLiteStmt struct {
 	mu     sync.Mutex
 	c      *SQLiteConn
@@ -236,13 +236,13 @@ type SQLiteStmt struct {
 	cls    bool
 }
 
-// SQLiteResult implement sql.Result.
+// SQLiteResult implements sql.Result.
 type SQLiteResult struct {
 	id      int64
 	changes int64
 }
 
-// SQLiteRows implement sql.Rows.
+// SQLiteRows implements driver.Rows.
 type SQLiteRows struct {
 	s        *SQLiteStmt
 	nc       int


### PR DESCRIPTION
sql.Driver, sql.Conn, sql.Tx sql.Stmt, and sql.Rows are not interfaces.
Updated the comments to refer to the correct interfaces: driver.Driver,
driver.Conn, driver.Tx, driver.Stmt, and driver.Rows.