### PR TITLE
Distinguish between NULL and zero-length blobs on query

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1987,7 +1987,7 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 		case C.SQLITE_BLOB:
 			p := C.sqlite3_column_blob(rc.s.s, C.int(i))
 			if p == nil {
-				dest[i] = nil
+				dest[i] = []byte{}
 				continue
 			}
 			n := int(C.sqlite3_column_bytes(rc.s.s, C.int(i)))

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1999,8 +1999,10 @@ func testNullZeroLengthBlobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if b1 == nil || len(b1) > 0 {
-		t.Errorf("for id=1, got nil; want zero-length slice")
+	if b1 == nil {
+		t.Error("for id=1, got nil; want zero-length slice")
+	} else if len(b1) > 0 {
+		t.Errorf("for id=1, got %x; want zero-length slice", b1)
 	}
 }
 

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1770,6 +1770,7 @@ var tests = []testing.InternalTest{
 	{Name: "TestResult", F: testResult},
 	{Name: "TestBlobs", F: testBlobs},
 	{Name: "TestMultiBlobs", F: testMultiBlobs},
+	{Name: "TestNullZeroLengthBlobs", F: testNullZeroLengthBlobs},
 	{Name: "TestManyQueryRow", F: testManyQueryRow},
 	{Name: "TestTxQuery", F: testTxQuery},
 	{Name: "TestPreparedStmt", F: testPreparedStmt},
@@ -1972,6 +1973,34 @@ func testMultiBlobs(t *testing.T) {
 	}
 	if got1 != want1 {
 		t.Errorf("for []byte, got %q; want %q", got1, want1)
+	}
+}
+
+// testBlobs tests that we distinguish between null and zero-length blobs
+func testNullZeroLengthBlobs(t *testing.T) {
+	db.tearDown()
+	db.mustExec("create table foo (id integer primary key, bar " + db.blobType(16) + ")")
+	db.mustExec(db.q("insert into foo (id, bar) values(?,?)"), 0, nil)
+	db.mustExec(db.q("insert into foo (id, bar) values(?,?)"), 1, []byte{})
+
+	r0 := db.QueryRow(db.q("select bar from foo where id=0"))
+	var b0 []byte
+	err := r0.Scan(&b0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b0 != nil {
+		t.Errorf("for id=0, got %x; want nil", b0)
+	}
+
+	r1 := db.QueryRow(db.q("select bar from foo where id=1"))
+	var b1 []byte
+	err = r1.Scan(&b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b1 == nil || len(b1) > 0 {
+		t.Errorf("for id=1, got nil; want zero-length slice")
 	}
 }
 


### PR DESCRIPTION
Map NULL to nil and non-NULL zero-length blobs to a zero-length byte slice.

This fixes #642.