### PR TITLE
Fix build failure on Windows/386

### DIFF
--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -19,6 +19,7 @@ extern void unlock_notify_callback(void *arg, int argc);
 import "C"
 import (
 	"fmt"
+	"math"
 	"sync"
 	"unsafe"
 )
@@ -59,7 +60,7 @@ func (t *unlock_notify_table) get(h uint) chan struct{} {
 //export unlock_notify_callback
 func unlock_notify_callback(argv unsafe.Pointer, argc C.int) {
 	for i := 0; i < int(argc); i++ {
-		parg := ((*(*[1 << 30]*[1]uint)(argv))[i])
+		parg := ((*(*[(math.MaxInt32 - 1) / unsafe.Sizeof(uintptr)]*[1]uint)(argv))[i])
 		arg := *parg
 		h := arg[0]
 		c := unt.get(h)


### PR DESCRIPTION
The array size exceeds the address space of 32-bit platform.
See https://github.com/mattn/go-sqlite3/issues/238