### PR TITLE
Fix build failure of incorrect expression for unsafe.Sizeof

### DIFF
--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -60,7 +60,7 @@ func (t *unlock_notify_table) get(h uint) chan struct{} {
 //export unlock_notify_callback
 func unlock_notify_callback(argv unsafe.Pointer, argc C.int) {
 	for i := 0; i < int(argc); i++ {
-		parg := ((*(*[(math.MaxInt32 - 1) / unsafe.Sizeof(uintptr)]*[1]uint)(argv))[i])
+		parg := ((*(*[(math.MaxInt32 - 1) / unsafe.Sizeof((*C.uint)(nil))]*[1]uint)(argv))[i])
 		arg := *parg
 		h := arg[0]
 		c := unt.get(h)


### PR DESCRIPTION
Emergency fix to make the CI happy again.
Tested on Linux/amd64.

I am still investigating how to test on Windows/386
