### PR TITLE
sqlite3_column_type SQLITE_TEXT returns string not []byte

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -223,7 +223,6 @@ var SQLiteTimestampFormats = []string{
 const (
 	columnDate      string = "date"
 	columnDatetime  string = "datetime"
-	columnText      string = "text"
 	columnTimestamp string = "timestamp"
 )
 
@@ -2062,14 +2061,8 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 					t = t.In(rc.s.c.loc)
 				}
 				dest[i] = t
-			case columnText:
-				dest[i] = s
 			default:
-				if strings.Contains(strings.ToLower(rc.decltype[i]), "char") {
-					dest[i] = s
-				} else {
-					dest[i] = []byte(s)
-				}
+				dest[i] = s
 			}
 		}
 	}

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -223,6 +223,7 @@ var SQLiteTimestampFormats = []string{
 const (
 	columnDate      string = "date"
 	columnDatetime  string = "datetime"
+	columnText      string = "text"
 	columnTimestamp string = "timestamp"
 )
 
@@ -2061,10 +2062,15 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 					t = t.In(rc.s.c.loc)
 				}
 				dest[i] = t
+			case columnText:
+				dest[i] = s
 			default:
-				dest[i] = []byte(s)
+				if strings.Contains(strings.ToLower(rc.decltype[i]), "char") {
+					dest[i] = s
+				} else {
+					dest[i] = []byte(s)
+				}
 			}
-
 		}
 	}
 	return nil


### PR DESCRIPTION
Return as `string` as opposed to `[]byte` or `[]uint8` arrays.

This brings sqlite closer in line with other dbs like postgres, allowing downstream consumers to assume the scanned value is string across underlying dbs.

This implementation is a first draft. If it's good as is, great, if not, let's start a dialog on the issue and figure out how best to resolve it.

This change is related to https://github.com/jinzhu/gorm/issues/2276 and https://github.com/mattn/go-sqlite3/issues/606.