### PR TITLE
darwin/libsqlite3: Also use the homebrew include path

### DIFF
--- a/sqlite3_libsqlite3.go
+++ b/sqlite3_libsqlite3.go
@@ -11,6 +11,7 @@ package sqlite3
 #cgo CFLAGS: -DUSE_LIBSQLITE3
 #cgo linux LDFLAGS: -lsqlite3
 #cgo darwin LDFLAGS: -L/usr/local/opt/sqlite/lib -lsqlite3
+#cgo darwin CFLAGS: -I/usr/local/opt/sqlite/include
 #cgo openbsd LDFLAGS: -lsqlite3
 #cgo solaris LDFLAGS: -lsqlite3
 */


### PR DESCRIPTION
When building on darwin with the `libsqlite3` tag, go-sqlite3 adds the
homebrew library path.  It does not, however, add the homebrew include
path, which means that the MacOS sqlite3 header is used instead.  On
my system, this results in build errors that look like this:

./sqlite3_load_extension.go:25:8: could not determine kind of name for C.sqlite3_enable_load_extension
./sqlite3_load_extension.go:33:8: could not determine kind of name for C.sqlite3_load_extension

Add the homebrew include path as well, so that he header matches the
libraries we're using.

Signed-off-by: George Dunlap <george.dunlap@citrix.com>