### PR TITLE
Add Go 1.12.x/1.13.x to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - master
 
 before_install:


### PR DESCRIPTION
Adds Go 1.12.x and 1.13.x to `.travis.yml` to test against newer releases.