### PR TITLE
Add extension-functions.c info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,16 @@ If you want your own extension to be listed here or you want to add a reference 
 Spatialite is available as an extension to SQLite, and can be used in combination with this repository.
 For an example see [shaxbee/go-spatialite](https://github.com/shaxbee/go-spatialite).
 
+## extension-functions.c from SQLite3 Contrib
+
+extension-functions.c is available as an extension to SQLite, and provides the following functions:
+
+- Math: acos, asin, atan, atn2, atan2, acosh, asinh, atanh, difference, degrees, radians, cos, sin, tan, cot, cosh, sinh, tanh, coth, exp, log, log10, power, sign, sqrt, square, ceil, floor, pi.
+- String: replicate, charindex, leftstr, rightstr, ltrim, rtrim, trim, replace, reverse, proper, padl, padr, padc, strfilter.
+- Aggregate: stdev, variance, mode, median, lower_quartile, upper_quartile
+
+For an example see [dinedal/go-sqlite3-extension-functions](https://github.com/dinedal/go-sqlite3-extension-functions).
+
 # FAQ
 
 - Getting insert error while query is opened.


### PR DESCRIPTION
One thing I've found SQLite3 lacking is a lot of common functions that many SQL databases have, such as stdev. These functions can be found for SQLite3 by the file `extension-functions.c` found on https://www.sqlite.org/contrib?orderby=date

I've copied the file to GitHub at https://github.com/dinedal/go-sqlite3-extension-functions and put together a very small CMake script so it will build in a cross-platform way.

`extension-functions.c` adds the following functions:

- Math: acos, asin, atan, atn2, atan2, acosh, asinh, atanh, difference, degrees, radians, cos, sin, tan, cot, cosh, sinh, tanh, coth, exp, log, log10, power, sign, sqrt, square, ceil, floor, pi.
- String: replicate, charindex, leftstr, rightstr, ltrim, rtrim, trim, replace, reverse, proper, padl, padr, padc, strfilter.
- Aggregate: stdev, variance, mode, median, lower_quartile, upper_quartile

Hopefully this makes it easier to get this functions more widespread.
