### PR TITLE
Fix for 'regex' early termination of returned rows

### DIFF
--- a/_example/mod_regexp/sqlite3_mod_regexp.c
+++ b/_example/mod_regexp/sqlite3_mod_regexp.c
@@ -13,9 +13,13 @@ static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv
     int vec[500];
     int n, rc;
     pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
+    if (!re) {
+      sqlite3_result_error(context, errstr, 0);
+      return;
+    }
     rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500); 
     if (rc <= 0) {
-      sqlite3_result_error(context, errstr, 0);
+      sqlite3_result_int(context, 0);
       return;
     }
     sqlite3_result_int(context, 1);


### PR DESCRIPTION
Once the regex encountered the first instance of a non-match, it would return without processing the rest of the rows in the statement. This change allows it to process the remaining, only setting the sqlite3_result_int to zero then continuing. This worked fine for the example as it only had one item to process.