### PR TITLE
Travis-CI: set go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go_import_path: github.com/mattn/go-sqlite3
+
 os:
   - linux
   - osx


### PR DESCRIPTION
Set `go_import_path` to tell Travis-CI where to checkout the code, so the Travis build can also work on forks. This is important when building without Go modules support.