### PR TITLE
Travis-CI: add Go 1.14.x, change order of Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ addons:
     update: true
 
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
+  - 1.14.x
+  - tip
   - 1.13.x
-  - master
+  - 1.12.x
+  - 1.11.x
+  - 1.10.x
+  - 1.9.x
 
 before_install:
   - |


### PR DESCRIPTION
Changes in Go versions for the Travis-CI builds:
- reverse order of Go versions so the latest ones are checked first (we get the most interesting results earlier)
- add Go 1.14.x (latest stable) at the first position
- use 'tip' instead of 'master' (like https://tip.golang.org) and move it just after 1.14.x