### PR TITLE
RowsColumnTypeNullable not implemented

### DIFF
--- a/sqlite3_type.go
+++ b/sqlite3_type.go
@@ -31,12 +31,12 @@ func (rc *SQLiteRows) ColumnTypeLength(index int) (length int64, ok bool) {
 func (rc *SQLiteRows) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
 	return 0, 0, false
 }
-*/
 
 // ColumnTypeNullable implement RowsColumnTypeNullable.
 func (rc *SQLiteRows) ColumnTypeNullable(i int) (nullable, ok bool) {
-	return true, true
+	return false, false
 }
+*/
 
 // ColumnTypeScanType implement RowsColumnTypeScanType.
 func (rc *SQLiteRows) ColumnTypeScanType(i int) reflect.Type {


### PR DESCRIPTION
Hello @mattn 

When I am trying the `columnType`'s `Nullable` method, seems it always returns `true` although it is not implemented yet, maybe we should comment out this method right now or always return `false`, `false`?

Thank you.