### PR TITLE
Use quote include instead of angled include for sqlite3-binding.h 

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -7,7 +7,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/callback.go
+++ b/callback.go
@@ -12,7 +12,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/error.go
+++ b/error.go
@@ -7,7 +7,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -24,7 +24,7 @@ package sqlite3
 #cgo CFLAGS: -Wno-deprecated-declarations
 #cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_context.go
+++ b/sqlite3_context.go
@@ -8,7 +8,7 @@ package sqlite3
 /*
 
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -9,7 +9,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -13,7 +13,7 @@ package sqlite3
 #cgo LDFLAGS: -lm
 
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_opt_unlock_notify.c
+++ b/sqlite3_opt_unlock_notify.c
@@ -5,7 +5,7 @@
 
 #ifdef SQLITE_ENABLE_UNLOCK_NOTIFY
 #include <stdio.h>
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 
 extern int unlock_notify_wait(sqlite3 *db);
 

--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -12,7 +12,7 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_ENABLE_UNLOCK_NOTIFY
 
 #include <stdlib.h>
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 
 extern void unlock_notify_callback(void *arg, int argc);
 */

--- a/sqlite3_opt_userauth.go
+++ b/sqlite3_opt_userauth.go
@@ -11,7 +11,7 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_USER_AUTHENTICATION
 #cgo LDFLAGS: -lm
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -19,7 +19,7 @@ package sqlite3
 #cgo CFLAGS: -Wno-deprecated-declarations
 
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_trace.go
+++ b/sqlite3_trace.go
@@ -9,7 +9,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif

--- a/sqlite3_type.go
+++ b/sqlite3_type.go
@@ -7,7 +7,7 @@ package sqlite3
 
 /*
 #ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
+#include "sqlite3-binding.h"
 #else
 #include <sqlite3.h>
 #endif


### PR DESCRIPTION
I'm trying to depend on this library using bazel. After upgrading to macOS Catalina I keep seeing the error:

```
/private/var/tmp/_bazel_i/292155d2803b74186baeb737a4c74ee8/sandbox/darwin-sandbox/550/execroot/project/external/com_github_mattn_go_sqlite3/backup.go:10:10: error: 'sqlite3-binding.h' file not found with <angled> include; use "quotes" instead
#include <sqlite3-binding.h>
         ^~~~~~~~~~~~~~~~~~~
         "sqlite3-binding.h
```

Hopefully this PR would fix the issue for using this library with bazel while not affecting any other use cases.