### PR TITLE
.github/workflows: stop using deprecated add-path command

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Add $GOPATH/bin to $PATH
         run: |
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - uses: actions/checkout@v2
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Add $GOPATH/bin to $PATH
         run: |
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: msys2 {0}
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Github is disabling the add-path command in workflows on 2020-11-16.
Switch to their new preferred way of doing this, by appending to the
file referred to with $GITHUB_PATH. See:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path

This should fix the following warning from the workflows:

```
.github#L1
The `add-path` command is deprecated and will be disabled on November
16th. Please upgrade to using Environment Files. For more information
see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```