### PR TITLE
sqlite3_test.go: Move Go 1.13 test to sqlite3_go113_test.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -90,7 +90,7 @@ ConnectHook to get the SQLiteConn.
 					},
 			})
 
-You can also use database/sql.Conn.Raw:
+You can also use database/sql.Conn.Raw (Go >= 1.13):
 
 	conn, err := db.Conn(context.Background())
 	// if err != nil { ... }

--- a/sqlite3_go113_test.go
+++ b/sqlite3_go113_test.go
@@ -49,6 +49,10 @@ func TestBeginTxCancel(t *testing.T) {
 				if !ok {
 					t.Fatal("unexpected: wrong type")
 				}
+				// checks that conn.Raw can be used to get *SQLiteConn
+				if _, ok = driverConn.(*SQLiteConn); !ok {
+					t.Fatalf("conn.Raw() driverConn type=%T, expected *SQLiteConn", driverConn)
+				}
 
 				go cancel() // make it cancel concurrently with exec("BEGIN");
 				tx, err := d.BeginTx(ctx, driver.TxOptions{})

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -9,7 +9,6 @@ package sqlite3
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -2351,34 +2350,5 @@ func benchmarkStmtRows(b *testing.B) {
 		if err = r.Err(); err != nil {
 			panic(err)
 		}
-	}
-}
-
-func TestConnRawIsSQLiteConn(t *testing.T) {
-	db, err := sql.Open("sqlite3", ":memory:")
-	if err != nil {
-		t.Fatal("Failed to open db:", err)
-	}
-	defer db.Close()
-
-	conn, err := db.Conn(context.Background())
-	if err != nil {
-		t.Fatal("Failed to get conn:", err)
-	}
-	defer conn.Close()
-	err = conn.Raw(func(driverConn interface{}) error {
-		sqliteConn, ok := driverConn.(*SQLiteConn)
-		if !ok {
-			t.Errorf("driverConn type=%T; expected to be *SQLiteConn", driverConn)
-			return nil
-		}
-		// call a private SQLite API to confirm the raw conn "works"
-		if sqliteConn.AuthEnabled() {
-			t.Error("sqliteConn.AuthEnabled()=true; expected false")
-		}
-		return nil
-	})
-	if err != nil {
-		t.Error("conn.Raw() returned err:", err)
 	}
 }


### PR DESCRIPTION
Commit 4f7abea96e added a test that uses Conn.Raw, which was added in
Go >= 1.13. The go-sqlite3 project runs tests with Go >= 1.11. Remove
the test from sqlite3_test.go, so it only runs with the correct
versions of Go.

Instead of adding a new test, modify the existing test that already
uses Conn.Raw() to check the type of driverConn.

Fixes issue from #882 