### PR TITLE
clarify usleep license

### DIFF
--- a/sqlite3_usleep_windows.go
+++ b/sqlite3_usleep_windows.go
@@ -15,7 +15,9 @@ package sqlite3
 // This code should improve performance on windows because
 // without the presence of usleep SQLite waits 1 second.
 //
-// Source: https://stackoverflow.com/questions/5801813/c-usleep-is-obsolete-workarounds-for-windows-mingw?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+// Source:  https://github.com/php/php-src/blob/PHP-5.0/win32/time.c
+// License: https://github.com/php/php-src/blob/PHP-5.0/LICENSE
+// Details: https://stackoverflow.com/questions/5801813/c-usleep-is-obsolete-workarounds-for-windows-mingw?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
 
 /*
 #include <windows.h>


### PR DESCRIPTION
This pull request helps clarify the license of the `usleep` function.  This `usleep` function originates from the PHP codebase and is therefore published under an OSI-approved license. However, linking to stackoverflow without linking back to the original source caused some problems during a recent license audit:

> Anything from stackoverflow is under the Creative Commons Attribution ShareAlike 4.0 license which requires that any code that remixes, transforms or builds upon the material on stackoverflow be distributed under the same license. So Go-sqllite3 could potentially be violating stackoverflow TOS.

This change should clarify that this file is open source and does not violate the stackoverflow TOS, and should help avoid any license compliance challenges in the future 🙂 

