### PR TITLE
Add ?_cache_size=[..] to connection parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Boolean values can be one of:
 | Time Zone Location | `_loc` | auto | Specify location of time format. |
 | Transaction Lock | `_txlock` | <ul><li>immediate</li><li>deferred</li><li>exclusive</li></ul> | Specify locking behavior for transactions. |
 | Writable Schema | `_writable_schema` | `Boolean` | When this pragma is on, the SQLITE_MASTER tables in which database can be changed using ordinary UPDATE, INSERT, and DELETE statements. Warning: misuse of this pragma can easily result in a corrupt database file. |
+| Cache Size | `_cache_size` | `int` | Maximum cache size; default is 2000K (2M). See [PRAGMA cache_size](https://sqlite.org/pragma.html#pragma_cache_size) |
+
 
 ## DSN Examples
 


### PR DESCRIPTION
Add a shortcut for PRAGMA cache_size; this is a pretty useful setting:
the default of -2000 (2M) is not especially high, and a lot of people
will probably want to increase this.

For example, while running a bunch of fairy expensive queries in
parallel:

	With SetMaxOpenConns(1):
	 -2000:  5762ms
	-20000:  4714ms

	With SetMaxOpenConns(20):
	 -2000:  3067ms
	-20000:  2532ms

Which isn't a bad performance boost for changing a single number.