### PR TITLE
Export sqlite3_stmt_readonly() via SQLiteStmt.Readonly()

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2007,6 +2007,13 @@ func (s *SQLiteStmt) execSync(args []namedValue) (driver.Result, error) {
 	return &SQLiteResult{id: int64(rowid), changes: int64(changes)}, nil
 }
 
+// Readonly reports if this statement is considered readonly by SQLite.
+//
+// See: https://sqlite.org/c3ref/stmt_readonly.html
+func (s *SQLiteStmt) Readonly() bool {
+	return C.sqlite3_stmt_readonly(s.s) == 1
+}
+
 // Close the rows.
 func (rc *SQLiteRows) Close() error {
 	rc.s.mu.Lock()


### PR DESCRIPTION
This can be used like in the test; I wrote a little wrapper around
sql.DB which uses this, and allows concurrent reads but just one single
write. This is perhaps a better generic "table locked"-solution than
setting the connections to 1 and/or cache=shared (although even better
would be to design your app in such a way that this doesn't happpen in
the first place, but even then a little seat belt isn't a bad thing).

The parsing adds about 0.1ms to 0.2ms of overhead in the wrapper, which
isn't too bad (and it caches the results, so only needs to do this
once).

At any rate, I can't really access functions from sqlite3-binding.c from
my application, so expose it via SQLiteStmt.