### PR TITLE
Make Error work work with and without cgo enabled

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,25 +1,16 @@
-// Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
-//
-// Use of this source code is governed by an MIT-style
-// license that can be found in the LICENSE file.
-
 package sqlite3
 
-/*
-#ifndef USE_LIBSQLITE3
-#include <sqlite3-binding.h>
-#else
-#include <sqlite3.h>
-#endif
-*/
-import "C"
 import "syscall"
+
+// Make sure the error interface is implemented.
+var (
+	_ error = Error{}
+	_ error = ErrNo(0)
+	_ error = ErrNoExtended(0)
+)
 
 // ErrNo inherit errno.
 type ErrNo int
-
-// ErrNoMask is mask code.
-const ErrNoMask C.int = 0xff
 
 // ErrNoExtended is extended errno.
 type ErrNoExtended int
@@ -73,24 +64,6 @@ func (err ErrNo) Error() string {
 // Extend return extended errno.
 func (err ErrNo) Extend(by int) ErrNoExtended {
 	return ErrNoExtended(int(err) | (by << 8))
-}
-
-// Error return error message that is extended code.
-func (err ErrNoExtended) Error() string {
-	return Error{Code: ErrNo(C.int(err) & ErrNoMask), ExtendedCode: err}.Error()
-}
-
-func (err Error) Error() string {
-	var str string
-	if err.err != "" {
-		str = err.err
-	} else {
-		str = C.GoString(C.sqlite3_errstr(C.int(err.Code)))
-	}
-	if err.SystemErrno != 0 {
-		str += ": " + err.SystemErrno.Error()
-	}
-	return str
 }
 
 // result codes from http://www.sqlite.org/c3ref/c_abort_rollback.html

--- a/error_cgo.go
+++ b/error_cgo.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// +build cgo
+
+package sqlite3
+
+/*
+#ifndef USE_LIBSQLITE3
+#include <sqlite3-binding.h>
+#else
+#include <sqlite3.h>
+#endif
+*/
+import "C"
+
+// ErrNoMask is mask code.
+const ErrNoMask C.int = 0xff
+
+// Error return error message that is extended code.
+func (err ErrNoExtended) Error() string {
+	return Error{Code: ErrNo(C.int(err) & ErrNoMask), ExtendedCode: err}.Error()
+}
+
+func (err Error) Error() string {
+	var str string
+	if err.err != "" {
+		str = err.err
+	} else {
+		str = C.GoString(C.sqlite3_errstr(C.int(err.Code)))
+	}
+	if err.SystemErrno != 0 {
+		str += ": " + err.SystemErrno.Error()
+	}
+	return str
+}

--- a/sqlite3_load_extension_test.go
+++ b/sqlite3_load_extension_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+// +build cgo
 // +build !sqlite_omit_load_extension
 
 package sqlite3

--- a/static_mock.go
+++ b/static_mock.go
@@ -35,3 +35,6 @@ func (c *SQLiteConn) RegisterCommitHook(func() int)                            {
 func (c *SQLiteConn) RegisterFunc(string, interface{}, bool) error             { return errorMsg }
 func (c *SQLiteConn) RegisterRollbackHook(func())                              {}
 func (c *SQLiteConn) RegisterUpdateHook(func(int, string, string, int64))      {}
+
+func (err Error) Error() string         { return "no error message in CGO_ENABLED=0" }
+func (err ErrNoExtended) Error() string { return Error{}.Error() }


### PR DESCRIPTION
Let's say you have the following code:

	// ErrUnique reports if this error reports a UNIQUE constraint violation.V
	func ErrUnique(err error) bool {
		var sqlErr *sqlite3.Error
		if errors.As(err, &sqlErr) && sqlErr.ExtendedCode == sqlite3.ErrConstraintUnique {
			return true
		}
		var pqErr *pq.Error
		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
			return true
		}
		return false
	}

This doesn't work with CGO_ENABLED=0 since:

	$ CGO_ENABLED=0 go test .
	# zgo.at/zdb [zgo.at/zdb.test]
	./zdb.go:16:14: undefined: sqlite3.Error
	./zdb.go:17:55: undefined: sqlite3.ErrConstraintUnique

Now, it's not too hard to create two implementations of this: a cgo version
which includes the SQLite and PostgreSQL check, and a non-cgo version which
includes just the PostgreSQL check, but it's all a bit cumbersome and requires
duplicate code or wrapper functions and more indirection than really needed.

Since there are just two methods that actually use the C "package", I think it
makes sense to put those in a error_cgo.go file, and put some basic shims in the
static_mock.go file – this way the code always compiles.