### PR TITLE
Resolve windows CI issues

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Get Build Tools
         run: |
-          GO111MODULE=on go get -u github.com/ory/go-acc
+          GO111MODULE=on go get github.com/ory/go-acc
         shell: msys2 {0}
 
       - name: Add $GOPATH/bin to $PATH


### PR DESCRIPTION
Do not use `-u` flag when fetching go-acc