### PR TITLE
Add error checking in simple example for tx.Commit

### DIFF
--- a/_example/simple/simple.go
+++ b/_example/simple/simple.go
@@ -42,7 +42,10 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	rows, err := db.Query("select id, name from foo")
 	if err != nil {


### PR DESCRIPTION
Based on https://golang.org/pkg/database/sql/#Tx.Commit this function returns an error type.
So why not check it.