### PR TITLE
bump codecov/codecov-action@v2

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -112,7 +112,7 @@ jobs:
         shell: msys2 {0}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           env_vars: OS,GO
           file: coverage.txt


### PR DESCRIPTION
`codecov/codecov-action@v2` is released and v2 is now deprecated.

> https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1
> Deprecration of v1
> On February 1, 2022, this version will be fully sunset and no longer function
> 
> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.
> 
> We will be restricting any updates to the v1 Action to security updates and hotfixes.

We should migrate from v1 to v2.