### PR TITLE
return non-nil result when calling exec with empty query

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -828,6 +828,10 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []namedValue) 
 		tail := s.(*SQLiteStmt).t
 		s.Close()
 		if tail == "" {
+			if res == nil {
+				// https://github.com/mattn/go-sqlite3/issues/963
+				res = &SQLiteResult{0, 0}
+			}
 			return res, nil
 		}
 		query = tail

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1943,6 +1943,7 @@ var tests = []testing.InternalTest{
 	{Name: "TestManyQueryRow", F: testManyQueryRow},
 	{Name: "TestTxQuery", F: testTxQuery},
 	{Name: "TestPreparedStmt", F: testPreparedStmt},
+	{Name: "TestExecEmptyQuery", F: testExecEmptyQuery},
 }
 
 var benchmarks = []testing.InternalBenchmark{
@@ -2271,6 +2272,25 @@ func testPreparedStmt(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// testEmptyQuery is test for validating the API in case of empty query
+func testExecEmptyQuery(t *testing.T) {
+	db.tearDown()
+	res, err := db.Exec(" -- this is just a comment ")
+	if err != nil {
+		t.Fatalf("empty query err: %v", err)
+	}
+
+	_, err = res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId returned an error: %v", err)
+	}
+
+	_, err = res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected returned an error: %v", err)
+	}
 }
 
 // Benchmarks need to use panic() since b.Error errors are lost when


### PR DESCRIPTION
### Proposed changes
- fixed `exec` to always return `driver.Result` even when there's nothing to actually run
- added test for calling `exec` with empty statement

fixes #963