### PR TITLE
Allow building on OpenBSD

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -21,6 +21,8 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
 #cgo CFLAGS: -Wno-deprecated-declarations
 #cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
+#cgo openbsd CFLAGS: -I/usr/local/include
+#cgo openbsd LDFLAGS: -L/usr/local/lib
 #ifndef USE_LIBSQLITE3
 #include <sqlite3-binding.h>
 #else


### PR DESCRIPTION
When launching` go build -x --tags "icu"`, build fails with

```
# github.com/mattn/go-sqlite3
sqlite3-binding.c:198677:10: fatal error: 'unicode/utypes.h' file not found
```

Add OpenBSD lib/include path.