### PR TITLE
Retract +incompatible releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/mattn/go-sqlite3
 
-go 1.12
+go 1.16
+
+retract (
+ [v2.0.0+incompatible, v2.0.6+incompatible] // Accidental; no major changes or features.
+)


### PR DESCRIPTION
(For #965.)

This retraction will take effect when this commit is included in the
latest v1 release (presumably v1.14.11).