### PR TITLE
Add explicit version instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ go-sqlite3
 [![codecov](https://codecov.io/gh/mattn/go-sqlite3/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-sqlite3)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mattn/go-sqlite3)](https://goreportcard.com/report/github.com/mattn/go-sqlite3)
 
-Latest stable version is v1.14 or later, not v2.
+Latest stable version is v1.14 or later, not v2. Install the currently-latest version using
+
+```
+$ go get github.com/mattn/go-sqlite3@v1.14.11
+```
 
 ~~**NOTE:** The increase to v2 was an accident. There were no major changes or features.~~
 


### PR DESCRIPTION
**Background**

I am working on implementing ent in a codebase. [The testing page of ent](https://entgo.io/docs/testing/) specifically recommends using this repository.

`go get`ting this repository installs an invalid version which only fails in a way that's really difficult to analyze. Figuring out what the root cause was and figuring out how to install the correct version has eaten up an unfortunate chunk of my day.

**Change**

It looks like there's some other work going on in PRs to remediate the version issue. This doesn't pretend to fix that, but gives developers who wind up on this page a really explicit and easy way to solve that versioning problem before it wrecks their days.

Cheers!