### PR TITLE
Fix windows build with icu tag

### DIFF
--- a/sqlite3_opt_icu.go
+++ b/sqlite3_opt_icu.go
@@ -14,6 +14,6 @@ package sqlite3
 #cgo darwin CFLAGS: -I/usr/local/opt/icu4c/include
 #cgo darwin LDFLAGS: -L/usr/local/opt/icu4c/lib -licui18n
 #cgo openbsd LDFLAGS: -lsqlite3 -licui18n
-#cgo windows LDFLAGS: -licuuc -licuin
+#cgo windows LDFLAGS: -licuin
 */
 import "C"

--- a/sqlite3_opt_icu.go
+++ b/sqlite3_opt_icu.go
@@ -8,10 +8,12 @@
 package sqlite3
 
 /*
-#cgo LDFLAGS: -licuuc -licui18n
+#cgo LDFLAGS: -licuuc
 #cgo CFLAGS: -DSQLITE_ENABLE_ICU
+#cgo linux LDFLAGS: -licui18n
 #cgo darwin CFLAGS: -I/usr/local/opt/icu4c/include
-#cgo darwin LDFLAGS: -L/usr/local/opt/icu4c/lib
-#cgo openbsd LDFLAGS: -lsqlite3
+#cgo darwin LDFLAGS: -L/usr/local/opt/icu4c/lib -licui18n
+#cgo openbsd LDFLAGS: -lsqlite3 -licui18n
+#cgo windows LDFLAGS: -licuuc -licuin
 */
 import "C"


### PR DESCRIPTION
In mingw64, [icu][] comes with `libicuin` instead of `libicui18n` library.

[icu]: https://packages.msys2.org/package/mingw-w64-x86_64-icu?repo=mingw64