### PR TITLE
Corrected RegisterPreUpdateHook Documentation

### DIFF
--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -33,7 +33,7 @@ import (
 // The callback is passed a SQLitePreUpdateData struct with the data for
 // the update, as well as methods for fetching copies of impacted data.
 //
-// If there is an existing update hook for this connection, it will be
+// If there is an existing preupdate hook for this connection, it will be
 // removed. If callback is nil the existing hook (if any) will be removed
 // without creating a new one.
 func (c *SQLiteConn) RegisterPreUpdateHook(callback func(SQLitePreUpdateData)) {

--- a/sqlite3_opt_preupdate_omit.go
+++ b/sqlite3_opt_preupdate_omit.go
@@ -13,7 +13,7 @@ package sqlite3
 // The callback is passed a SQLitePreUpdateData struct with the data for
 // the update, as well as methods for fetching copies of impacted data.
 //
-// If there is an existing update hook for this connection, it will be
+// If there is an existing preupdate hook for this connection, it will be
 // removed. If callback is nil the existing hook (if any) will be removed
 // without creating a new one.
 func (c *SQLiteConn) RegisterPreUpdateHook(callback func(SQLitePreUpdateData)) {


### PR DESCRIPTION
This PR updates comments for the RegisterPreUpdateHook wrapper/connection methods to accurately reflect the SQLite behavior of this hook. Resolves #1034.