### PR TITLE
&dest should be dest in pre update hook when getting old/new row

### DIFF
--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -84,7 +84,7 @@ func (d *SQLitePreUpdateData) row(dest []interface{}, new bool) error {
 			src = nil
 		}
 
-		err := convertAssign(&dest[i], src)
+		err := convertAssign(dest[i], src)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since the `dest` slice is already an address, taking the address of the address when updating the values causes the values to be lost in the caller