### PR TITLE
Add simple Dockerfile in "_example/simple" and its test

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,22 @@
+name: dockerfile
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  dockerfile:
+    name: Run Dockerfiles in examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run example - simple
+        run: |
+          cd ./_example/simple
+          docker build -t simple .
+          docker run simple | grep 99\ こんにちわ世界099

--- a/_example/simple/Dockerfile
+++ b/_example/simple/Dockerfile
@@ -1,0 +1,45 @@
+# =============================================================================
+#  Multi-stage Dockerfile Example
+# =============================================================================
+#  This is a simple Dockerfile that will build an image of scratch-base image.
+#  Usage:
+#    docker build -t simple:local . && docker run --rm simple:local
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+#  Build Stage
+# -----------------------------------------------------------------------------
+FROM golang:alpine AS build
+
+# Important:
+#   Because this is a CGO enabled package, you are required to set it as 1.
+ENV CGO_ENABLED=1
+
+RUN apk add --no-cache \
+    # Important: required for go-sqlite3
+    gcc \
+    # Required for Alpine
+    musl-dev
+
+WORKDIR /workspace
+
+COPY . /workspace/
+
+RUN \
+    go mod init github.com/mattn/sample && \
+    go mod tidy && \
+    go install -ldflags="-s -w -extldflags \"-static\"" ./simple.go
+
+RUN \
+    # Smoke test
+    set -o pipefail; \
+    /go/bin/simple | grep 99\ こんにちわ世界099
+
+# -----------------------------------------------------------------------------
+#  Main Stage
+# -----------------------------------------------------------------------------
+FROM scratch
+
+COPY --from=build /go/bin/simple /usr/local/bin/simple
+
+ENTRYPOINT [ "/usr/local/bin/simple" ]

--- a/_example/simple/Dockerfile
+++ b/_example/simple/Dockerfile
@@ -28,7 +28,7 @@ COPY . /workspace/
 RUN \
     go mod init github.com/mattn/sample && \
     go mod tidy && \
-    go install -ldflags="-s -w -extldflags \"-static\"" ./simple.go
+    go install -ldflags='-s -w -extldflags "-static"' ./simple.go
 
 RUN \
     # Smoke test


### PR DESCRIPTION
This PR adds an example of building a `scratch`-based Docker image using a multi-stage build.

It also includes simple tests of containers built with GitHub Actions.

This is a PoC type, which means that if the correct compiler is used and the application is built statically and correctly, the built application binary will work correctly without additional installation.

This Dockerfile example may help isolate the problem for those struggling with 'CGO_ENABLED' and static build.