### PR TITLE
Add build tags to support both x86 and ARM compilation on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package follows the official [Golang Release Policy](https://golang.org/doc
     - [Alpine](#alpine)
     - [Fedora](#fedora)
     - [Ubuntu](#ubuntu)
-  - [Mac OSX](#mac-osx)
+  - [macOS X](#mac-osx)
   - [Windows](#windows)
   - [Errors](#errors)
 - [User Authentication](#user-authentication)
@@ -215,8 +215,8 @@ This library can be cross-compiled.
 
 In some cases you are required to the `CC` environment variable with the cross compiler.
 
-## Cross Compiling from MAC OSX
-The simplest way to cross compile from OSX is to use [xgo](https://github.com/karalabe/xgo).
+## Cross Compiling from macOS X
+The simplest way to cross compile from macOS X is to use [xgo](https://github.com/karalabe/xgo).
 
 Steps:
 - Install [xgo](https://github.com/karalabe/xgo) (`go get github.com/karalabe/xgo`).
@@ -267,9 +267,9 @@ sudo yum groupinstall "Development Tools" "Development Libraries"
 sudo apt-get install build-essential
 ```
 
-## Mac OSX
+## macOS X
 
-OSX should have all the tools present to compile this package. If not, install XCode to add all the developers tools.
+macOS X should have all the tools present to compile this package. If not, install XCode to add all the developers tools.
 
 Required dependency:
 
@@ -277,7 +277,7 @@ Required dependency:
 brew install sqlite3
 ```
 
-For OSX, there is an additional package to install which is required if you wish to build the `icu` extension.
+For macOS X, there is an additional package to install which is required if you wish to build the `icu` extension.
 
 This additional package can be installed with `homebrew`:
 
@@ -285,16 +285,25 @@ This additional package can be installed with `homebrew`:
 brew upgrade icu4c
 ```
 
-To compile for Mac OSX:
+To compile for macOS X on x86:
 
 ```bash
-go build --tags "darwin"
+go build --tags "darwin,amd64"
+```
+
+To compile for macOS X on ARM chips:
+
+```bash
+go build --tags "darwin,arm64"
 ```
 
 If you wish to link directly to libsqlite3, use the `libsqlite3` build tag:
 
 ```
-go build --tags "libsqlite3 darwin"
+# x86 
+go build --tags "libsqlite3 darwin amd64"
+# ARM
+go build --tags "libsqlite3 darwin arm64"
 ```
 
 Additional information:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Click [here](https://golang.org/pkg/go/build/#hdr-Build_Constraints) for more in
 If you wish to build this library with additional extensions / features, use the following command:
 
 ```bash
-go build --tags "<FEATURE>"
+go build -tags "<FEATURE>"
 ```
 
 For available features, see the extension list.
@@ -154,7 +154,7 @@ When using multiple build tags, all the different tags should be space delimited
 Example:
 
 ```bash
-go build --tags "icu json1 fts5 secure_delete"
+go build -tags "icu json1 fts5 secure_delete"
 ```
 
 ### Feature / Extension List
@@ -190,7 +190,7 @@ This package can be compiled for android.
 Compile with:
 
 ```bash
-go build --tags "android"
+go build -tags "android"
 ```
 
 For more information see [#201](https://github.com/mattn/go-sqlite3/issues/201)
@@ -238,13 +238,13 @@ To compile this package on Linux, you must install the development tools for you
 To compile under linux use the build tag `linux`.
 
 ```bash
-go build --tags "linux"
+go build -tags "linux"
 ```
 
 If you wish to link directly to libsqlite3 then you can use the `libsqlite3` build tag.
 
 ```
-go build --tags "libsqlite3 linux"
+go build -tags "libsqlite3 linux"
 ```
 
 ### Alpine
@@ -294,16 +294,16 @@ go build -tags "darwin amd64"
 To compile for macOS on ARM chips:
 
 ```bash
-go build --tags "darwin arm64"
+go build -tags "darwin arm64"
 ```
 
 If you wish to link directly to libsqlite3, use the `libsqlite3` build tag:
 
 ```
 # x86 
-go build --tags "libsqlite3 darwin amd64"
+go build -tags "libsqlite3 darwin amd64"
 # ARM
-go build --tags "libsqlite3 darwin arm64"
+go build -tags "libsqlite3 darwin arm64"
 ```
 
 Additional information:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This package follows the official [Golang Release Policy](https://golang.org/doc
     - [Alpine](#alpine)
     - [Fedora](#fedora)
     - [Ubuntu](#ubuntu)
-  - [macOS X](#mac-osx)
+  - [macOS](#mac-osx)
   - [Windows](#windows)
   - [Errors](#errors)
 - [User Authentication](#user-authentication)
@@ -215,8 +215,8 @@ This library can be cross-compiled.
 
 In some cases you are required to the `CC` environment variable with the cross compiler.
 
-## Cross Compiling from macOS X
-The simplest way to cross compile from macOS X is to use [xgo](https://github.com/karalabe/xgo).
+## Cross Compiling from macOS
+The simplest way to cross compile from macOS is to use [xgo](https://github.com/karalabe/xgo).
 
 Steps:
 - Install [xgo](https://github.com/karalabe/xgo) (`go get github.com/karalabe/xgo`).
@@ -267,9 +267,9 @@ sudo yum groupinstall "Development Tools" "Development Libraries"
 sudo apt-get install build-essential
 ```
 
-## macOS X
+## macOS
 
-macOS X should have all the tools present to compile this package. If not, install XCode to add all the developers tools.
+macOS should have all the tools present to compile this package. If not, install XCode to add all the developers tools.
 
 Required dependency:
 
@@ -277,7 +277,7 @@ Required dependency:
 brew install sqlite3
 ```
 
-For macOS X, there is an additional package to install which is required if you wish to build the `icu` extension.
+For macOS, there is an additional package to install which is required if you wish to build the `icu` extension.
 
 This additional package can be installed with `homebrew`:
 
@@ -285,13 +285,13 @@ This additional package can be installed with `homebrew`:
 brew upgrade icu4c
 ```
 
-To compile for macOS X on x86:
+To compile for macOS on x86:
 
 ```bash
-go build --tags "darwin amd64"
+go build -tags "darwin amd64"
 ```
 
-To compile for macOS X on ARM chips:
+To compile for macOS on ARM chips:
 
 ```bash
 go build --tags "darwin arm64"

--- a/README.md
+++ b/README.md
@@ -288,13 +288,13 @@ brew upgrade icu4c
 To compile for macOS X on x86:
 
 ```bash
-go build --tags "darwin,amd64"
+go build --tags "darwin amd64"
 ```
 
 To compile for macOS X on ARM chips:
 
 ```bash
-go build --tags "darwin,arm64"
+go build --tags "darwin arm64"
 ```
 
 If you wish to link directly to libsqlite3, use the `libsqlite3` build tag:

--- a/sqlite3_libsqlite3.go
+++ b/sqlite3_libsqlite3.go
@@ -10,8 +10,10 @@ package sqlite3
 /*
 #cgo CFLAGS: -DUSE_LIBSQLITE3
 #cgo linux LDFLAGS: -lsqlite3
-#cgo darwin LDFLAGS: -L/usr/local/opt/sqlite/lib -lsqlite3
-#cgo darwin CFLAGS: -I/usr/local/opt/sqlite/include
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/sqlite/lib -lsqlite3
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/sqlite/include
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/sqlite/lib -lsqlite3
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/sqlite/include
 #cgo openbsd LDFLAGS: -lsqlite3
 #cgo solaris LDFLAGS: -lsqlite3
 #cgo windows LDFLAGS: -lsqlite3

--- a/sqlite3_opt_icu.go
+++ b/sqlite3_opt_icu.go
@@ -10,8 +10,10 @@ package sqlite3
 /*
 #cgo LDFLAGS: -licuuc -licui18n
 #cgo CFLAGS: -DSQLITE_ENABLE_ICU
-#cgo darwin CFLAGS: -I/usr/local/opt/icu4c/include
-#cgo darwin LDFLAGS: -L/usr/local/opt/icu4c/lib
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/icu4c/include
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/icu4c/lib
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/icu4c/include
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/icu4c/lib
 #cgo openbsd LDFLAGS: -lsqlite3
 */
 import "C"


### PR DESCRIPTION
Fix for #1068 

**Changes**

* Introduce `arm64` and `amd64` build tags
* Appropriate changes in documentation