### PR TITLE
remove unuseful ldflags for windows platform.

### DIFF
--- a/sqlite3_windows.go
+++ b/sqlite3_windows.go
@@ -12,7 +12,6 @@ package sqlite3
 #cgo CFLAGS: -fno-stack-check
 #cgo CFLAGS: -fno-stack-protector
 #cgo CFLAGS: -mno-stack-arg-probe
-#cgo LDFLAGS: -lmingwex -lmingw32
 #cgo windows,386 CFLAGS: -D_USE_32BIT_TIME_T
 */
 import "C"


### PR DESCRIPTION
Golang's linker add mingwex and mingw32 automatically,so we don't need add them manually.