### PR TITLE
Cross Compiling for Mac OS via `musl-cross`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,13 @@ This library can be cross-compiled.
 In some cases you are required to the `CC` environment variable with the cross compiler.
 
 ## Cross Compiling from MAC OSX
-The simplest way to cross compile from OSX is to use [xgo](https://github.com/karalabe/xgo).
+The simplest way to cross compile from OSX is to use [musl-cross](https://github.com/FiloSottile/homebrew-musl-cross).
 
 Steps:
-- Install [xgo](https://github.com/karalabe/xgo) (`go get github.com/karalabe/xgo`).
-- Ensure that your project is within your `GOPATH`.
-- Run `xgo local/path/to/project`.
+- Install [musl-cross](https://github.com/FiloSottile/homebrew-musl-cross) (`brew install FiloSottile/musl-cross/musl-cross`).
+- Run `CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++ GOARCH=amd64 GOOS=linux CGO_ENABLED=1 go build -ldflags "-linkmode external -extldflags -static"`.
 
-Please refer to the project's [README](https://github.com/karalabe/xgo/blob/master/README.md) for further information.
+Please refer to the project's [README](https://github.com/FiloSottile/homebrew-musl-cross#readme) for further information.
 
 # Google Cloud Platform
 


### PR DESCRIPTION
# Enhancement

Update `README.md` with new instructions for Mac OS cross compiling.

# Why?

The current suggested solution `xgo` is no longer maintained (GitHub archived repository).

# Credits

Credits go to Pieter Claerhout (@pieterclaerhout) and his blog post: https://www.yellowduck.be/posts/cross-compile-a-go-package-which-uses-sqlite3