### PR TITLE
Updating vtable example, "BestIndex" method

### DIFF
--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -63,7 +63,12 @@ func (v *ghRepoTable) Open() (sqlite3.VTabCursor, error) {
 }
 
 func (v *ghRepoTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
-	return &sqlite3.IndexResult{}, nil
+	used := make([]bool, len(csts))
+	return &sqlite3.IndexResult{
+		IdxNum: 0,
+		IdxStr: "default",
+		Used:   used,
+	}, nil
 }
 
 func (v *ghRepoTable) Disconnect() error { return nil }


### PR DESCRIPTION
As it was, the vtable example will give an error when adding any kind of SQL constraint in the SQL statement. Updating the BestIndex method will ensure that adding SQL constraints will not result in errors

Signed-off-by: David Vassallo <davevassallo@gmail.com>