### PR TITLE
Update README.md to include vtable feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ go build --tags "icu json1 fts5 secure_delete"
 | Secure Delete (FAST) | sqlite_secure_delete_fast | For more information see [PRAGMA secure_delete](https://www.sqlite.org/pragma.html#pragma_secure_delete) |
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
+| Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/mattn/go-sqlite3/tree/master/_example/vtable) |
 
 # Compilation
 


### PR DESCRIPTION
I almost missed the sqlite_vtable build tag since it wasnt listed as a "feature" in the README.md. Added for the next newbie like me that comes around 😃 

Signed-off-by: David Vassallo <davevassallo@gmail.com>