### PR TITLE
all: format with Go 1.19

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/callback.go
+++ b/callback.go
@@ -360,11 +360,11 @@ func callbackRetGeneric(ctx *C.sqlite3_context, v reflect.Value) error {
 	}
 
 	cb, err := callbackRet(v.Elem().Type())
-        if err != nil {
-                return err
-        }
+	if err != nil {
+		return err
+	}
 
-        return cb(ctx, v.Elem())
+	return cb(ctx, v.Elem())
 }
 
 func callbackRet(typ reflect.Type) (callbackRetConverter, error) {

--- a/callback_test.go
+++ b/callback_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/doc.go
+++ b/doc.go
@@ -5,63 +5,63 @@ This works as a driver for database/sql.
 
 Installation
 
-    go get github.com/mattn/go-sqlite3
+	go get github.com/mattn/go-sqlite3
 
-Supported Types
+# Supported Types
 
 Currently, go-sqlite3 supports the following data types.
 
-    +------------------------------+
-    |go        | sqlite3           |
-    |----------|-------------------|
-    |nil       | null              |
-    |int       | integer           |
-    |int64     | integer           |
-    |float64   | float             |
-    |bool      | integer           |
-    |[]byte    | blob              |
-    |string    | text              |
-    |time.Time | timestamp/datetime|
-    +------------------------------+
+	+------------------------------+
+	|go        | sqlite3           |
+	|----------|-------------------|
+	|nil       | null              |
+	|int       | integer           |
+	|int64     | integer           |
+	|float64   | float             |
+	|bool      | integer           |
+	|[]byte    | blob              |
+	|string    | text              |
+	|time.Time | timestamp/datetime|
+	+------------------------------+
 
-SQLite3 Extension
+# SQLite3 Extension
 
 You can write your own extension module for sqlite3. For example, below is an
 extension for a Regexp matcher operation.
 
-    #include <pcre.h>
-    #include <string.h>
-    #include <stdio.h>
-    #include <sqlite3ext.h>
+	#include <pcre.h>
+	#include <string.h>
+	#include <stdio.h>
+	#include <sqlite3ext.h>
 
-    SQLITE_EXTENSION_INIT1
-    static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
-      if (argc >= 2) {
-        const char *target  = (const char *)sqlite3_value_text(argv[1]);
-        const char *pattern = (const char *)sqlite3_value_text(argv[0]);
-        const char* errstr = NULL;
-        int erroff = 0;
-        int vec[500];
-        int n, rc;
-        pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
-        rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500);
-        if (rc <= 0) {
-          sqlite3_result_error(context, errstr, 0);
-          return;
-        }
-        sqlite3_result_int(context, 1);
-      }
-    }
+	SQLITE_EXTENSION_INIT1
+	static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+		if (argc >= 2) {
+			const char *target  = (const char *)sqlite3_value_text(argv[1]);
+			const char *pattern = (const char *)sqlite3_value_text(argv[0]);
+			const char* errstr = NULL;
+			int erroff = 0;
+			int vec[500];
+			int n, rc;
+			pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
+			rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500);
+			if (rc <= 0) {
+				sqlite3_result_error(context, errstr, 0);
+				return;
+			}
+			sqlite3_result_int(context, 1);
+		}
+	}
 
-    #ifdef _WIN32
-    __declspec(dllexport)
-    #endif
-    int sqlite3_extension_init(sqlite3 *db, char **errmsg,
-          const sqlite3_api_routines *api) {
-      SQLITE_EXTENSION_INIT2(api);
-      return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8,
-          (void*)db, regexp_func, NULL, NULL);
-    }
+	#ifdef _WIN32
+	__declspec(dllexport)
+	#endif
+	int sqlite3_extension_init(sqlite3 *db, char **errmsg,
+			const sqlite3_api_routines *api) {
+		SQLITE_EXTENSION_INIT2(api);
+		return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8,
+			(void*)db, regexp_func, NULL, NULL);
+	}
 
 It needs to be built as a so/dll shared library. And you need to register
 the extension module like below.
@@ -77,18 +77,18 @@ Then, you can use this extension.
 
 	rows, err := db.Query("select text from mytable where name regexp '^golang'")
 
-Connection Hook
+# Connection Hook
 
 You can hook and inject your code when the connection is established by setting
 ConnectHook to get the SQLiteConn.
 
 	sql.Register("sqlite3_with_hook_example",
-			&sqlite3.SQLiteDriver{
-					ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-						sqlite3conn = append(sqlite3conn, conn)
-						return nil
-					},
-			})
+		&sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				sqlite3conn = append(sqlite3conn, conn)
+				return nil
+			},
+		})
 
 You can also use database/sql.Conn.Raw (Go >= 1.13):
 
@@ -101,7 +101,7 @@ You can also use database/sql.Conn.Raw (Go >= 1.13):
 	})
 	// if err != nil { ... }
 
-Go SQlite3 Extensions
+# Go SQlite3 Extensions
 
 If you want to register Go functions as SQLite extension functions
 you can make a custom driver by calling RegisterFunction from
@@ -111,11 +111,11 @@ ConnectHook.
 		return regexp.MatchString(re, s)
 	}
 	sql.Register("sqlite3_extended",
-			&sqlite3.SQLiteDriver{
-					ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-						return conn.RegisterFunc("regexp", regex, true)
-					},
-			})
+		&sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				return conn.RegisterFunc("regexp", regex, true)
+			},
+		})
 
 You can then use the custom driver by passing its name to sql.Open.
 
@@ -130,6 +130,5 @@ You can then use the custom driver by passing its name to sql.Open.
 	}
 
 See the documentation of RegisterFunc for more details.
-
 */
 package sqlite3

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -971,103 +971,104 @@ func (c *SQLiteConn) begin(ctx context.Context) (driver.Tx, error) {
 // The argument is may be either in parentheses or it may be separated from
 // the pragma name by an equal sign. The two syntaxes yield identical results.
 // In many pragmas, the argument is a boolean. The boolean can be one of:
-//    1 yes true on
-//    0 no false off
+//
+//	1 yes true on
+//	0 no false off
 //
 // You can specify a DSN string using a URI as the filename.
-//   test.db
-//   file:test.db?cache=shared&mode=memory
-//   :memory:
-//   file::memory:
 //
-//   mode
-//     Access mode of the database.
-//     https://www.sqlite.org/c3ref/open.html
-//     Values:
-//      - ro
-//      - rw
-//      - rwc
-//      - memory
+//	test.db
+//	file:test.db?cache=shared&mode=memory
+//	:memory:
+//	file::memory:
 //
-//   cache
-//     SQLite Shared-Cache Mode
-//     https://www.sqlite.org/sharedcache.html
-//     Values:
-//       - shared
-//       - private
+//	mode
+//	  Access mode of the database.
+//	  https://www.sqlite.org/c3ref/open.html
+//	  Values:
+//	   - ro
+//	   - rw
+//	   - rwc
+//	   - memory
 //
-//   immutable=Boolean
-//     The immutable parameter is a boolean query parameter that indicates
-//     that the database file is stored on read-only media. When immutable is set,
-//     SQLite assumes that the database file cannot be changed,
-//     even by a process with higher privilege,
-//     and so the database is opened read-only and all locking and change detection is disabled.
-//     Caution: Setting the immutable property on a database file that
-//     does in fact change can result in incorrect query results and/or SQLITE_CORRUPT errors.
+//	cache
+//	  SQLite Shared-Cache Mode
+//	  https://www.sqlite.org/sharedcache.html
+//	  Values:
+//	    - shared
+//	    - private
+//
+//	immutable=Boolean
+//	  The immutable parameter is a boolean query parameter that indicates
+//	  that the database file is stored on read-only media. When immutable is set,
+//	  SQLite assumes that the database file cannot be changed,
+//	  even by a process with higher privilege,
+//	  and so the database is opened read-only and all locking and change detection is disabled.
+//	  Caution: Setting the immutable property on a database file that
+//	  does in fact change can result in incorrect query results and/or SQLITE_CORRUPT errors.
 //
 // go-sqlite3 adds the following query parameters to those used by SQLite:
-//   _loc=XXX
-//     Specify location of time format. It's possible to specify "auto".
 //
-//   _mutex=XXX
-//     Specify mutex mode. XXX can be "no", "full".
+//	_loc=XXX
+//	  Specify location of time format. It's possible to specify "auto".
 //
-//   _txlock=XXX
-//     Specify locking behavior for transactions.  XXX can be "immediate",
-//     "deferred", "exclusive".
+//	_mutex=XXX
+//	  Specify mutex mode. XXX can be "no", "full".
 //
-//   _auto_vacuum=X | _vacuum=X
-//     0 | none - Auto Vacuum disabled
-//     1 | full - Auto Vacuum FULL
-//     2 | incremental - Auto Vacuum Incremental
+//	_txlock=XXX
+//	  Specify locking behavior for transactions.  XXX can be "immediate",
+//	  "deferred", "exclusive".
 //
-//   _busy_timeout=XXX"| _timeout=XXX
-//     Specify value for sqlite3_busy_timeout.
+//	_auto_vacuum=X | _vacuum=X
+//	  0 | none - Auto Vacuum disabled
+//	  1 | full - Auto Vacuum FULL
+//	  2 | incremental - Auto Vacuum Incremental
 //
-//   _case_sensitive_like=Boolean | _cslike=Boolean
-//     https://www.sqlite.org/pragma.html#pragma_case_sensitive_like
-//     Default or disabled the LIKE operation is case-insensitive.
-//     When enabling this options behaviour of LIKE will become case-sensitive.
+//	_busy_timeout=XXX"| _timeout=XXX
+//	  Specify value for sqlite3_busy_timeout.
 //
-//   _defer_foreign_keys=Boolean | _defer_fk=Boolean
-//     Defer Foreign Keys until outermost transaction is committed.
+//	_case_sensitive_like=Boolean | _cslike=Boolean
+//	  https://www.sqlite.org/pragma.html#pragma_case_sensitive_like
+//	  Default or disabled the LIKE operation is case-insensitive.
+//	  When enabling this options behaviour of LIKE will become case-sensitive.
 //
-//   _foreign_keys=Boolean | _fk=Boolean
-//     Enable or disable enforcement of foreign keys.
+//	_defer_foreign_keys=Boolean | _defer_fk=Boolean
+//	  Defer Foreign Keys until outermost transaction is committed.
 //
-//   _ignore_check_constraints=Boolean
-//     This pragma enables or disables the enforcement of CHECK constraints.
-//     The default setting is off, meaning that CHECK constraints are enforced by default.
+//	_foreign_keys=Boolean | _fk=Boolean
+//	  Enable or disable enforcement of foreign keys.
 //
-//   _journal_mode=MODE | _journal=MODE
-//     Set journal mode for the databases associated with the current connection.
-//     https://www.sqlite.org/pragma.html#pragma_journal_mode
+//	_ignore_check_constraints=Boolean
+//	  This pragma enables or disables the enforcement of CHECK constraints.
+//	  The default setting is off, meaning that CHECK constraints are enforced by default.
 //
-//   _locking_mode=X | _locking=X
-//     Sets the database connection locking-mode.
-//     The locking-mode is either NORMAL or EXCLUSIVE.
-//     https://www.sqlite.org/pragma.html#pragma_locking_mode
+//	_journal_mode=MODE | _journal=MODE
+//	  Set journal mode for the databases associated with the current connection.
+//	  https://www.sqlite.org/pragma.html#pragma_journal_mode
 //
-//   _query_only=Boolean
-//     The query_only pragma prevents all changes to database files when enabled.
+//	_locking_mode=X | _locking=X
+//	  Sets the database connection locking-mode.
+//	  The locking-mode is either NORMAL or EXCLUSIVE.
+//	  https://www.sqlite.org/pragma.html#pragma_locking_mode
 //
-//   _recursive_triggers=Boolean | _rt=Boolean
-//     Enable or disable recursive triggers.
+//	_query_only=Boolean
+//	  The query_only pragma prevents all changes to database files when enabled.
 //
-//   _secure_delete=Boolean|FAST
-//     When secure_delete is on, SQLite overwrites deleted content with zeros.
-//     https://www.sqlite.org/pragma.html#pragma_secure_delete
+//	_recursive_triggers=Boolean | _rt=Boolean
+//	  Enable or disable recursive triggers.
 //
-//   _synchronous=X | _sync=X
-//     Change the setting of the "synchronous" flag.
-//     https://www.sqlite.org/pragma.html#pragma_synchronous
+//	_secure_delete=Boolean|FAST
+//	  When secure_delete is on, SQLite overwrites deleted content with zeros.
+//	  https://www.sqlite.org/pragma.html#pragma_secure_delete
 //
-//   _writable_schema=Boolean
-//     When this pragma is on, the SQLITE_MASTER tables in which database
-//     can be changed using ordinary UPDATE, INSERT, and DELETE statements.
-//     Warning: misuse of this pragma can easily result in a corrupt database file.
+//	_synchronous=X | _sync=X
+//	  Change the setting of the "synchronous" flag.
+//	  https://www.sqlite.org/pragma.html#pragma_synchronous
 //
-//
+//	_writable_schema=Boolean
+//	  When this pragma is on, the SQLITE_MASTER tables in which database
+//	  can be changed using ordinary UPDATE, INSERT, and DELETE statements.
+//	  Warning: misuse of this pragma can easily result in a corrupt database file.
 func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	if C.sqlite3_threadsafe() == 0 {
 		return nil, errors.New("sqlite library was not compiled for thread-safe operation")

--- a/sqlite3_go113_test.go
+++ b/sqlite3_go113_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.13 && cgo
 // +build go1.13,cgo
 
 package sqlite3

--- a/sqlite3_go18.go
+++ b/sqlite3_go18.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build cgo
-// +build go1.8
+//go:build cgo && go1.8
+// +build cgo,go1.8
 
 package sqlite3
 

--- a/sqlite3_go18_test.go
+++ b/sqlite3_go18_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.8 && cgo
 // +build go1.8,cgo
 
 package sqlite3

--- a/sqlite3_libsqlite3.go
+++ b/sqlite3_libsqlite3.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build libsqlite3
 // +build libsqlite3
 
 package sqlite3

--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_omit_load_extension
 // +build !sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_load_extension_omit.go
+++ b/sqlite3_load_extension_omit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_omit_load_extension
 // +build sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_load_extension_test.go
+++ b/sqlite3_load_extension_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_omit_load_extension
 // +build !sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_opt_allow_uri_authority.go
+++ b/sqlite3_opt_allow_uri_authority.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_allow_uri_authority
 // +build sqlite_allow_uri_authority
 
 package sqlite3

--- a/sqlite3_opt_app_armor.go
+++ b/sqlite3_opt_app_armor.go
@@ -4,8 +4,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !windows
-// +build sqlite_app_armor
+//go:build !windows && sqlite_app_armor
+// +build !windows,sqlite_app_armor
 
 package sqlite3
 

--- a/sqlite3_opt_column_metadata.go
+++ b/sqlite3_opt_column_metadata.go
@@ -1,3 +1,4 @@
+//go:build sqlite_column_metadata
 // +build sqlite_column_metadata
 
 package sqlite3

--- a/sqlite3_opt_column_metadata_test.go
+++ b/sqlite3_opt_column_metadata_test.go
@@ -1,3 +1,4 @@
+//go:build sqlite_column_metadata
 // +build sqlite_column_metadata
 
 package sqlite3

--- a/sqlite3_opt_foreign_keys.go
+++ b/sqlite3_opt_foreign_keys.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_foreign_keys
 // +build sqlite_foreign_keys
 
 package sqlite3

--- a/sqlite3_opt_fts3_test.go
+++ b/sqlite3_opt_fts3_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_opt_fts5.go
+++ b/sqlite3_opt_fts5.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_fts5 || fts5
 // +build sqlite_fts5 fts5
 
 package sqlite3

--- a/sqlite3_opt_icu.go
+++ b/sqlite3_opt_icu.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_icu || icu
 // +build sqlite_icu icu
 
 package sqlite3

--- a/sqlite3_opt_introspect.go
+++ b/sqlite3_opt_introspect.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_introspect
 // +build sqlite_introspect
 
 package sqlite3

--- a/sqlite3_opt_math_functions.go
+++ b/sqlite3_opt_math_functions.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_math_functions
 // +build sqlite_math_functions
 
 package sqlite3

--- a/sqlite3_opt_math_functions_test.go
+++ b/sqlite3_opt_math_functions_test.go
@@ -1,3 +1,4 @@
+//go:build sqlite_math_functions
 // +build sqlite_math_functions
 
 package sqlite3

--- a/sqlite3_opt_preupdate.go
+++ b/sqlite3_opt_preupdate.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_preupdate_hook
 // +build sqlite_preupdate_hook
 
 package sqlite3

--- a/sqlite3_opt_preupdate_hook_test.go
+++ b/sqlite3_opt_preupdate_hook_test.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_preupdate_hook
 // +build sqlite_preupdate_hook
 
 package sqlite3

--- a/sqlite3_opt_preupdate_omit.go
+++ b/sqlite3_opt_preupdate_omit.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_preupdate_hook && cgo
 // +build !sqlite_preupdate_hook,cgo
 
 package sqlite3

--- a/sqlite3_opt_secure_delete.go
+++ b/sqlite3_opt_secure_delete.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_secure_delete
 // +build sqlite_secure_delete
 
 package sqlite3

--- a/sqlite3_opt_secure_delete_fast.go
+++ b/sqlite3_opt_secure_delete_fast.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_secure_delete_fast
 // +build sqlite_secure_delete_fast
 
 package sqlite3

--- a/sqlite3_opt_serialize.go
+++ b/sqlite3_opt_serialize.go
@@ -1,3 +1,4 @@
+//go:build !libsqlite3 || sqlite_serialize
 // +build !libsqlite3 sqlite_serialize
 
 package sqlite3

--- a/sqlite3_opt_serialize_omit.go
+++ b/sqlite3_opt_serialize_omit.go
@@ -1,3 +1,4 @@
+//go:build libsqlite3 && !sqlite_serialize
 // +build libsqlite3,!sqlite_serialize
 
 package sqlite3

--- a/sqlite3_opt_serialize_test.go
+++ b/sqlite3_opt_serialize_test.go
@@ -1,3 +1,4 @@
+//go:build !libsqlite3 || sqlite_serialize
 // +build !libsqlite3 sqlite_serialize
 
 package sqlite3

--- a/sqlite3_opt_stat4.go
+++ b/sqlite3_opt_stat4.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_stat4
 // +build sqlite_stat4
 
 package sqlite3

--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build cgo
-// +build sqlite_unlock_notify
+//go:build cgo && sqlite_unlock_notify
+// +build cgo,sqlite_unlock_notify
 
 package sqlite3
 

--- a/sqlite3_opt_unlock_notify_test.go
+++ b/sqlite3_opt_unlock_notify_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_unlock_notify
 // +build sqlite_unlock_notify
 
 package sqlite3

--- a/sqlite3_opt_userauth.go
+++ b/sqlite3_opt_userauth.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_userauth
 // +build sqlite_userauth
 
 package sqlite3
@@ -79,7 +80,7 @@ var (
 // If a database contains the SQLITE_USER table, then the
 // call to Authenticate must be invoked with an
 // appropriate username and password prior to enable read and write
-//access to the database.
+// access to the database.
 //
 // Return SQLITE_OK on success or SQLITE_ERROR if the username/password
 // combination is incorrect or unknown.
@@ -103,9 +104,10 @@ func (c *SQLiteConn) Authenticate(username, password string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authenticate(username, password string) int {
 	// Allocate C Variables
 	cuser := C.CString(username)
@@ -155,9 +157,10 @@ func (c *SQLiteConn) AuthUserAdd(username, password string, admin bool) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserAdd(username, password string, admin int) int {
 	// Allocate C Variables
 	cuser := C.CString(username)
@@ -207,9 +210,10 @@ func (c *SQLiteConn) AuthUserChange(username, password string, admin bool) error
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserChange(username, password string, admin int) int {
 	// Allocate C Variables
 	cuser := C.CString(username)
@@ -249,9 +253,10 @@ func (c *SQLiteConn) AuthUserDelete(username string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserDelete(username string) int {
 	// Allocate C Variables
 	cuser := C.CString(username)
@@ -280,8 +285,9 @@ func (c *SQLiteConn) AuthEnabled() (exists bool) {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	0 - Disabled
-//  1 - Enabled
+//	1 - Enabled
 func (c *SQLiteConn) authEnabled() int {
 	return int(C._sqlite3_auth_enabled(c.db))
 }

--- a/sqlite3_opt_userauth_omit.go
+++ b/sqlite3_opt_userauth_omit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_userauth
 // +build !sqlite_userauth
 
 package sqlite3
@@ -17,7 +18,7 @@ import (
 // If a database contains the SQLITE_USER table, then the
 // call to Authenticate must be invoked with an
 // appropriate username and password prior to enable read and write
-//access to the database.
+// access to the database.
 //
 // Return SQLITE_OK on success or SQLITE_ERROR if the username/password
 // combination is incorrect or unknown.
@@ -34,9 +35,10 @@ func (c *SQLiteConn) Authenticate(username, password string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authenticate(username, password string) int {
 	// NOOP
 	return 0
@@ -65,9 +67,10 @@ func (c *SQLiteConn) AuthUserAdd(username, password string, admin bool) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserAdd(username, password string, admin int) int {
 	// NOOP
 	return 0
@@ -96,9 +99,10 @@ func (c *SQLiteConn) AuthUserChange(username, password string, admin bool) error
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserChange(username, password string, admin int) int {
 	// NOOP
 	return 0
@@ -122,9 +126,10 @@ func (c *SQLiteConn) AuthUserDelete(username string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserDelete(username string) int {
 	// NOOP
 	return 0
@@ -142,8 +147,9 @@ func (c *SQLiteConn) AuthEnabled() (exists bool) {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	0 - Disabled
-//  1 - Enabled
+//	1 - Enabled
 func (c *SQLiteConn) authEnabled() int {
 	// NOOP
 	return 0

--- a/sqlite3_opt_userauth_test.go
+++ b/sqlite3_opt_userauth_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_userauth
 // +build sqlite_userauth
 
 package sqlite3

--- a/sqlite3_opt_vacuum_full.go
+++ b/sqlite3_opt_vacuum_full.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vacuum_full
 // +build sqlite_vacuum_full
 
 package sqlite3

--- a/sqlite3_opt_vacuum_incr.go
+++ b/sqlite3_opt_vacuum_incr.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vacuum_incr
 // +build sqlite_vacuum_incr
 
 package sqlite3

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vtable || vtable
 // +build sqlite_vtable vtable
 
 package sqlite3

--- a/sqlite3_other.go
+++ b/sqlite3_other.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package sqlite3

--- a/sqlite3_solaris.go
+++ b/sqlite3_solaris.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build solaris
 // +build solaris
 
 package sqlite3

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1128,7 +1128,7 @@ func TestQueryer(t *testing.T) {
 		if err != nil {
 			t.Error("Failed to db.Query:", err)
 		}
-		if id != n + 1 {
+		if id != n+1 {
 			t.Error("Failed to db.Query: not matched results")
 		}
 		n = n + 1
@@ -1497,28 +1497,28 @@ func TestAggregatorRegistration(t *testing.T) {
 }
 
 type mode struct {
-        counts   map[interface{}]int
-        top      interface{}
-        topCount int
+	counts   map[interface{}]int
+	top      interface{}
+	topCount int
 }
 
 func newMode() *mode {
-        return &mode{
-                counts: map[interface{}]int{},
-        }
+	return &mode{
+		counts: map[interface{}]int{},
+	}
 }
 
 func (m *mode) Step(x interface{}) {
-        m.counts[x]++
-        c := m.counts[x]
-        if c > m.topCount {
-                m.top = x
-                m.topCount = c
-        }
+	m.counts[x]++
+	c := m.counts[x]
+	if c > m.topCount {
+		m.top = x
+		m.topCount = c
+	}
 }
 
 func (m *mode) Done() interface{} {
-        return m.top
+	return m.top
 }
 
 func TestAggregatorRegistration_GenericReturn(t *testing.T) {
@@ -1534,19 +1534,19 @@ func TestAggregatorRegistration_GenericReturn(t *testing.T) {
 	defer db.Close()
 
 	_, err = db.Exec("create table foo (department integer, profits integer)")
-        if err != nil {
-                t.Fatal("Failed to create table:", err)
-        }
-        _, err = db.Exec("insert into foo values (1, 10), (1, 20), (1, 45), (2, 42), (2, 115), (2, 20)")
-        if err != nil {
-                t.Fatal("Failed to insert records:", err)
-        }
+	if err != nil {
+		t.Fatal("Failed to create table:", err)
+	}
+	_, err = db.Exec("insert into foo values (1, 10), (1, 20), (1, 45), (2, 42), (2, 115), (2, 20)")
+	if err != nil {
+		t.Fatal("Failed to insert records:", err)
+	}
 
 	var mode int
-        err = db.QueryRow("select mode(profits) from foo").Scan(&mode)
-        if err != nil {
-                t.Fatal("MODE query error:", err)
-        }
+	err = db.QueryRow("select mode(profits) from foo").Scan(&mode)
+	if err != nil {
+		t.Fatal("MODE query error:", err)
+	}
 
 	if mode != 20 {
 		t.Fatal("Got incorrect mode. Wanted 20, got: ", mode)

--- a/sqlite3_trace.go
+++ b/sqlite3_trace.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_trace || trace
 // +build sqlite_trace trace
 
 package sqlite3

--- a/sqlite3_usleep_windows.go
+++ b/sqlite3_usleep_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_windows.go
+++ b/sqlite3_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package sqlite3

--- a/static_mock.go
+++ b/static_mock.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !cgo
 // +build !cgo
 
 package sqlite3


### PR DESCRIPTION
Update Go source files to use the '//go:build' lines introduced by Go 1.17 and the doc comment formatting introduced by Go 1.19. This formatting is not changed by Go 1.20.

Note: `doc.go` and the `*userauth*` files  had to be manually changed in some places to fix indentation.

This does not change how `godoc` (at least with Go 1.19) renders the package documentation and is backwards compatible (i.e. earlier versions of `gofmt` will leave this code unchanged - tested with 1.17). 