### PR TITLE
Proposal: sub-packages to enable optional features

### DIFF
--- a/fts5/fts5.go
+++ b/fts5/fts5.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2023 Simon Ser <contact@emersion.fr>
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package fts5
+
+/*
+#cgo CFLAGS: -DSQLITE_ENABLE_FTS5
+#cgo LDFLAGS: -lm
+*/
+import "C"

--- a/sqlite3_opt_fts5.go
+++ b/sqlite3_opt_fts5.go
@@ -7,8 +7,4 @@
 
 package sqlite3
 
-/*
-#cgo CFLAGS: -DSQLITE_ENABLE_FTS5
-#cgo LDFLAGS: -lm
-*/
-import "C"
+import _ "github.com/mattn/go-sqlite3/fts5"


### PR DESCRIPTION
A common pain point when using go-sqlite3 is that enabling optional features requires adding a build tag to all `go` command invocations. For instance, when a program depends on FTS5, it's no longer possible to run `go build`, `go test`, etc as usual. End users need to explicitly add `-tags sqlite_fts5` every time.

Here is a proposal to improve this. A new `fts5` sub-package is introduce. Any program which depends on FTS5 can import it to turn on FTS5:

```go
import _ "github.com/mattn/go-sqlite3/fts5"
```

What do you think?