### PR TITLE
go.mod: go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/mattn/go-sqlite3
 
-go 1.16
+go 1.18
 
-retract (
- [v2.0.0+incompatible, v2.0.6+incompatible] // Accidental; no major changes or features.
-)
+retract [v2.0.0+incompatible, v2.0.6+incompatible] // Accidental; no major changes or features.


### PR DESCRIPTION
go.mod's go version should match the oldest entry in github workflow.