### PR TITLE
Support "BEGIN CONCURRENT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Boolean values can be one of:
 | Shared-Cache Mode | `cache` | <ul><li>shared</li><li>private</li></ul> | Set cache mode for more information see [sqlite.org](https://www.sqlite.org/sharedcache.html) |
 | Synchronous | `_synchronous` \| `_sync` | <ul><li>0 \| OFF</li><li>1 \| NORMAL</li><li>2 \| FULL</li><li>3 \| EXTRA</li></ul> | For more information see [PRAGMA synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) |
 | Time Zone Location | `_loc` | auto | Specify location of time format. |
-| Transaction Lock | `_txlock` | <ul><li>immediate</li><li>deferred</li><li>exclusive</li></ul> | Specify locking behavior for transactions. |
+| Transaction Lock | `_txlock` | <ul><li>immediate</li><li>deferred</li><li>exclusive</li><li>concurrent</li></ul> | Specify locking behavior for transactions. |
 | Writable Schema | `_writable_schema` | `Boolean` | When this pragma is on, the SQLITE_MASTER tables in which database can be changed using ordinary UPDATE, INSERT, and DELETE statements. Warning: misuse of this pragma can easily result in a corrupt database file. |
 | Cache Size | `_cache_size` | `int` | Maximum cache size; default is 2000K (2M). See [PRAGMA cache_size](https://sqlite.org/pragma.html#pragma_cache_size) |
 

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1148,6 +1148,8 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		// _txlock
 		if val := params.Get("_txlock"); val != "" {
 			switch strings.ToLower(val) {
+			case "concurrent":
+				txlock = "BEGIN CONCURRENT"
 			case "immediate":
 				txlock = "BEGIN IMMEDIATE"
 			case "exclusive":


### PR DESCRIPTION
SQLite supports a "BEGIN CONCURRENT" transaction mode which cannot currently be used with the go-sqlite3 library.

See https://www.sqlite.org/cgi/src/doc/begin-concurrent/doc/begin_concurrent.md for details