### PR TITLE
Fix virtual table example.

### DIFF
--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -62,7 +62,7 @@ func (v *ghRepoTable) Open() (sqlite3.VTabCursor, error) {
 	return &ghRepoCursor{0, repos}, nil
 }
 
-func (v *ghRepoTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
+func (v *ghRepoTable) BestIndex(csts []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
 	used := make([]bool, len(csts))
 	return &sqlite3.IndexResult{
 		IdxNum: 0,


### PR DESCRIPTION
`csts` is used on 66, but parameter passed in is `cst` leading to a compile error.