### PR TITLE
sqlite3: don't copy string in bind()

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1953,7 +1953,7 @@ func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
 				if len(v) == 0 {
 					rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.int(0))
 				} else {
-					b := []byte(v)
+					b := *(*[]byte)(unsafe.Pointer(&v))
 					rv = C._sqlite3_bind_text(s.s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
 				}
 			case int64:


### PR DESCRIPTION
Change bind() to pass sqlite3_bind_text() a pointer to the strings data instead of converting it to a []byte just so a pointer to `&b[0]` can be passed to unsafe.Pointer. Basically, this saves a needless allocation. and passing a pointer to that.

This is safe because sqlite3_bind_text does not keep a copy of the provided string.