### PR TITLE
New txlock options for hinting RO transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Boolean values can be one of:
 | Shared-Cache Mode | `cache` | <ul><li>shared</li><li>private</li></ul> | Set cache mode for more information see [sqlite.org](https://www.sqlite.org/sharedcache.html) |
 | Synchronous | `_synchronous` \| `_sync` | <ul><li>0 \| OFF</li><li>1 \| NORMAL</li><li>2 \| FULL</li><li>3 \| EXTRA</li></ul> | For more information see [PRAGMA synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) |
 | Time Zone Location | `_loc` | auto | Specify location of time format. |
-| Transaction Lock | `_txlock` | <ul><li>immediate</li><li>deferred</li><li>exclusive</li></ul> | Specify locking behavior for transactions. |
+| Transaction Lock | `_txlock` | <ul><li>immediate</li><li>immediate-deferred</li><li>deferred</li><li>exclusive</li><li>exclusive-deferred</li></ul> | Specify locking behavior for transactions. The -deferred versions create a deferred transaction if `TxOptions.ReadOnly` is set. |
 | Writable Schema | `_writable_schema` | `Boolean` | When this pragma is on, the SQLITE_MASTER tables in which database can be changed using ordinary UPDATE, INSERT, and DELETE statements. Warning: misuse of this pragma can easily result in a corrupt database file. |
 | Cache Size | `_cache_size` | `int` | Maximum cache size; default is 2000K (2M). See [PRAGMA cache_size](https://sqlite.org/pragma.html#pragma_cache_size) |
 

--- a/sqlite3_go18.go
+++ b/sqlite3_go18.go
@@ -40,7 +40,7 @@ func (c *SQLiteConn) PrepareContext(ctx context.Context, query string) (driver.S
 
 // BeginTx implement ConnBeginTx.
 func (c *SQLiteConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	return c.begin(ctx)
+	return c.begin(ctx, opts.ReadOnly)
 }
 
 // QueryContext implement QueryerContext.


### PR DESCRIPTION
If an application doesn't have a retry logic when a read only transaction is being automatically upgraded to a write one in the default deferred mode SQLite will immediately return SQLITE_BUSY instead of honoring the busy timeout.

To workaround this one can use _txlock=immediate option to always go into write lock when starting a transaction. Depending on the application this might not be always wanted.

The Go SQL layer provides a mechanism to request a read only transaction but SQLite doesn't support completely disabling writes within a transaction. However, we can use it to hint that we might not do any writes so we'd instead want a deferred BEGIN.

Because this isn't very standards compliant in any way adding new _txlock options was chosen so it can be selected when desired.