### PR TITLE
Fix musl build (#1164)

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -21,7 +21,6 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1
 #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
 #cgo CFLAGS: -Wno-deprecated-declarations
-#cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
 #cgo openbsd CFLAGS: -I/usr/local/include
 #cgo openbsd LDFLAGS: -L/usr/local/lib
 #ifndef USE_LIBSQLITE3
@@ -46,6 +45,18 @@ package sqlite3
 
 #ifndef SQLITE_DETERMINISTIC
 # define SQLITE_DETERMINISTIC 0
+#endif
+
+#if defined(HAVE_PREAD64) && defined(HAVE_PWRITE64)
+# undef USE_PREAD
+# undef USE_PWRITE
+# define USE_PREAD64 1
+# define USE_PWRITE64 1
+#elif defined(HAVE_PREAD) && defined(HAVE_PWRITE)
+# undef USE_PREAD
+# undef USE_PWRITE
+# define USE_PREAD64 1
+# define USE_PWRITE64 1
 #endif
 
 static int


### PR DESCRIPTION
As pointed out by @jefferyto the LFS64 interfaces were marked as deprecated in musl 1.2.4 ([release notes](https://musl.libc.org/releases.html), [commit](https://git.musl-libc.org/cgit/musl/commit/?h=v1.2.4&id=25e6fee27f4a293728dd15b659170e7b9c7db9bc)), thus go-sqlite3 currently fails to compile on musl.

This PR adjusts CLFAGS to let the C implementation use `pread()`/`pwrite()` instead of `pread64()`/`pwrite64()`.

Note: This change does not affect existing glibc builds as suggested by the [pread64 man page](https://linux.die.net/man/2/pread64):
> On Linux, the underlying system calls were renamed in kernel 2.6: pread() became pread64(), and pwrite() became pwrite64(). The system call numbers remained the same. The glibc pread() and pwrite() wrapper functions transparently deal with the change.