### PR TITLE
Add SetErrorLog function

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -16,6 +16,7 @@ package sqlite3
 #else
 #include <sqlite3.h>
 #endif
+#include <stdint.h>
 #include <stdlib.h>
 
 void _sqlite3_result_text(sqlite3_context* ctx, const char* s, int n);
@@ -32,6 +33,13 @@ import (
 	"sync/atomic"
 	"unsafe"
 )
+
+var errorLogCallback atomic.Value
+
+//export errorLogTrampoline
+func errorLogTrampoline(_ C.uintptr_t, errCode C.int, msg *C.char) {
+	errorLogCallback.Load().(func(Error, string))(errorFromCode(errCode), C.GoString(msg))
+}
 
 //export callbackTrampoline
 func callbackTrampoline(ctx *C.sqlite3_context, argc C.int, argv **C.sqlite3_value) {

--- a/callback.go
+++ b/callback.go
@@ -16,6 +16,7 @@ package sqlite3
 #else
 #include <sqlite3.h>
 #endif
+#include <stdint.h>
 #include <stdlib.h>
 
 void _sqlite3_result_text(sqlite3_context* ctx, const char* s, int n);
@@ -29,8 +30,16 @@ import (
 	"math"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
+
+var errorLogCallback atomic.Value
+
+//export errorLogTrampoline
+func errorLogTrampoline(_ C.uintptr_t, errCode C.int, msg *C.char) {
+	errorLogCallback.Load().(func(Error, string))(errorFromCode(errCode), C.GoString(msg))
+}
 
 //export callbackTrampoline
 func callbackTrampoline(ctx *C.sqlite3_context, argc int, argv **C.sqlite3_value) {

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -59,6 +59,13 @@ package sqlite3
 # define USE_PWRITE64 1
 #endif
 
+void errorLogTrampoline(void *userPtr, int errCode, const char *msg);
+
+static int
+_sqlite3_config_log() {
+  return sqlite3_config(SQLITE_CONFIG_LOG, &errorLogTrampoline, NULL);
+}
+
 static int
 _sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zVfs) {
 #ifdef SQLITE_OPEN_URI
@@ -347,14 +354,35 @@ func Version() (libVersion string, libVersionNumber int, sourceID string) {
 	return libVersion, libVersionNumber, sourceID
 }
 
+// SetErrorLog registers the given callback to be invoked with a message whenever SQLite detects an
+// anomaly. It is good practice to redirect such messages to the application log. See
+// https://sqlite.org/errlog.html.
+// The provided callback function receives an SQLite error object, denoting the broad category of
+// error, and a message string. It must not call any SQLite functions; in fact, the SQLite docs
+// recommend treating the callback function like a signal handler, minimizing the work done in it.
+// SetErrorLog must not be called while any other goroutine is running that might be calling into
+// the SQLite library.
+func SetErrorLog(callback func(err Error, msg string)) error {
+	errorLogCallback.Store(callback)
+	if rc := C._sqlite3_config_log(); rc == 0 {
+		return nil
+	} else {
+		return errorFromCode(rc)
+	}
+}
+
 const (
+	// some common return codes
+	SQLITE_OK      = C.SQLITE_OK
+	SQLITE_NOTICE  = C.SQLITE_NOTICE
+	SQLITE_WARNING = C.SQLITE_WARNING
+
 	// used by authorizer and pre_update_hook
 	SQLITE_DELETE = C.SQLITE_DELETE
 	SQLITE_INSERT = C.SQLITE_INSERT
 	SQLITE_UPDATE = C.SQLITE_UPDATE
 
-	// used by authorzier - as return value
-	SQLITE_OK     = C.SQLITE_OK
+	// used by authorizer as return value, in addition to SQLITE_OK
 	SQLITE_IGNORE = C.SQLITE_IGNORE
 	SQLITE_DENY   = C.SQLITE_DENY
 
@@ -937,6 +965,13 @@ func lastError(db *C.sqlite3) error {
 		ExtendedCode: ErrNoExtended(extrv),
 		SystemErrno:  systemErrno,
 		err:          errStr,
+	}
+}
+
+func errorFromCode(rc C.int) Error {
+	return Error{
+		Code:         ErrNo(rc & ErrNoMask),
+		ExtendedCode: ErrNoExtended(rc),
 	}
 }
 

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -59,6 +59,13 @@ package sqlite3
 # define USE_PWRITE64 1
 #endif
 
+void errorLogTrampoline(void *userPtr, int errCode, const char *msg);
+
+static int
+_sqlite3_config_log() {
+  return sqlite3_config(SQLITE_CONFIG_LOG, &errorLogTrampoline, NULL);
+}
+
 static int
 _sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zVfs) {
 #ifdef SQLITE_OPEN_URI
@@ -347,14 +354,35 @@ func Version() (libVersion string, libVersionNumber int, sourceID string) {
 	return libVersion, libVersionNumber, sourceID
 }
 
+// SetErrorLog registers the given callback to be invoked with a message whenever SQLite detects an
+// anomaly. It is good practice to redirect such messages to the application log. See
+// https://sqlite.org/errlog.html.
+// The provided callback function receives an SQLite error object, denoting the broad category of
+// error, and a message string. It must not call any SQLite functions; in fact, the SQLite docs
+// recommend treating the callback function like a signal handler, minimizing the work done in it.
+// SetErrorLog must not be called while any other goroutine is running that might be calling into
+// the SQLite library.
+func SetErrorLog(callback func(err Error, msg string)) error {
+	errorLogCallback.Store(callback)
+	if rc := C._sqlite3_config_log(); rc == 0 {
+		return nil
+	} else {
+		return errorFromCode(rc)
+	}
+}
+
 const (
+	// some common return codes
+	SQLITE_OK      = C.SQLITE_OK
+	SQLITE_NOTICE  = C.SQLITE_NOTICE
+	SQLITE_WARNING = C.SQLITE_WARNING
+
 	// used by authorizer and pre_update_hook
 	SQLITE_DELETE = C.SQLITE_DELETE
 	SQLITE_INSERT = C.SQLITE_INSERT
 	SQLITE_UPDATE = C.SQLITE_UPDATE
 
-	// used by authorzier - as return value
-	SQLITE_OK     = C.SQLITE_OK
+	// used by authorizer as return value, in addition to SQLITE_OK
 	SQLITE_IGNORE = C.SQLITE_IGNORE
 	SQLITE_DENY   = C.SQLITE_DENY
 
@@ -943,6 +971,13 @@ func lastError(db *C.sqlite3) error {
 		ExtendedCode: ErrNoExtended(extrv),
 		SystemErrno:  systemErrno,
 		err:          errStr,
+	}
+}
+
+func errorFromCode(rc C.int) Error {
+	return Error{
+		Code:         ErrNo(rc & ErrNoMask),
+		ExtendedCode: ErrNoExtended(rc),
 	}
 }
 


### PR DESCRIPTION
This function sets a callback that SQLite invokes when it detects an anomaly. See https://sqlite.org/errlog.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an error logging callback API for receiving SQLite warnings and error messages.
  * Added constants for common SQLite notice and warning return codes.
  * Error callbacks now include the SQLite error code and descriptive message.

* **Bug Fixes**
  * Improved reporting of SQLite anomalies that previously could go unnoticed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->