### PR TITLE
bugfix: after executing statement table lock was not cleared

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2083,6 +2083,12 @@ func (s *SQLiteStmt) execSync(args []driver.NamedValue) (driver.Result, error) {
 		return nil, err
 	}
 
+	rv = C.sqlite3_reset(s.s)
+	if rv != C.SQLITE_OK {
+		err := s.c.lastError()
+		C.sqlite3_clear_bindings(s.s)
+		return nil, err
+	}
 	return &SQLiteResult{id: int64(rowid), changes: int64(changes)}, nil
 }
 

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -2101,6 +2101,7 @@ var tests = []testing.InternalTest{
 	{Name: "TestManyQueryRow", F: testManyQueryRow},
 	{Name: "TestTxQuery", F: testTxQuery},
 	{Name: "TestPreparedStmt", F: testPreparedStmt},
+	{Name: "TestExecStmtDoesNotBlockTable", F: testExecStmtDoesNotBlockTable},
 	{Name: "TestExecEmptyQuery", F: testExecEmptyQuery},
 }
 
@@ -2430,6 +2431,40 @@ func testPreparedStmt(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// testExecStmtDoesNotBlockTable tests that the tables' locks are cleared after
+// executing a statement.
+func testExecStmtDoesNotBlockTable(t *testing.T) {
+	db.tearDown()
+	db.mustExec("CREATE TABLE t (count INT)")
+	sel, err := db.Prepare("SELECT count FROM t")
+	if err != nil {
+		t.Fatalf("prepare 1: %v", err)
+	}
+	ins, err := db.Prepare(db.q("INSERT INTO t (count) VALUES (?)"))
+	if err != nil {
+		t.Fatalf("prepare 2: %v", err)
+	}
+	drop, err := db.Prepare(db.q("DROP TABLE t"))
+	if err != nil {
+		t.Fatalf("prepare 3: %v", err)
+	}
+
+	for n := 1; n <= 3; n++ {
+		if _, err := ins.Exec(n); err != nil {
+			t.Fatalf("insert(%d) = %v", n, err)
+		}
+	}
+
+	_, err = sel.Exec()
+	if err != nil {
+		t.Fatalf("exec 1: %v", err)
+	}
+	_, err = drop.Exec()
+	if err != nil {
+		t.Fatalf("exec 2: %v", err)
+	}
 }
 
 // testEmptyQuery is test for validating the API in case of empty query


### PR DESCRIPTION
When we execute a statement, we step once and return. If the query returned more than one row, we would not have consumed everything so the underlying table would still be locked even when the execution had finished.

This change resets the statement after execution so that the locks can be cleared.

Apart from the included test, the following go program serves to reproduce the issue:
```golang
package main

import (
	"context"
	"database/sql"

	_ "github.com/mattn/go-sqlite3"
)

func main() {
	ctx := context.Background()
	sqldb, err := sql.Open("sqlite3", "file:test.db?cache=shared&mode=memory")

	stmt, err := sqldb.PrepareContext(ctx, "CREATE TABLE person (id number, name text);")
	stmt.Exec()
	stmt, err = sqldb.PrepareContext(ctx, "INSERT INTO person VALUES (1, 'Fred'), (2, 'Susan');")
	stmt.Exec()

	stmt, err = sqldb.PrepareContext(ctx, "SELECT name FROM person;")
	_, err = stmt.ExecContext(context.Background())

	stmt, err = sqldb.Prepare("DROP TABLE person;")
	_, err = stmt.ExecContext(ctx)
	if err != nil {
		panic(err) // panic: database table is locked
	}
}
```