### PR TITLE
WIP: Allow custom window functions to be registered

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -42,14 +42,36 @@ func callbackTrampoline(ctx *C.sqlite3_context, argc int, argv **C.sqlite3_value
 //export stepTrampoline
 func stepTrampoline(ctx *C.sqlite3_context, argc C.int, argv **C.sqlite3_value) {
 	args := (*[(math.MaxInt32 - 1) / unsafe.Sizeof((*C.sqlite3_value)(nil))]*C.sqlite3_value)(unsafe.Pointer(argv))[:int(argc):int(argc)]
-	ai := lookupHandle(C.sqlite3_user_data(ctx)).(*aggInfo)
-	ai.Step(ctx, args)
+	if ai, ok := lookupHandle(C.sqlite3_user_data(ctx)).(*aggInfo); ok {
+		ai.Step(ctx, args)
+	}
+	if window, ok := lookupHandle(C.sqlite3_user_data(ctx)).(*windowAggInfo); ok {
+		window.Step(ctx, args)
+	}
+}
+
+//export inverseTrampoline
+func inverseTrampoline(ctx *C.sqlite3_context, argc C.int, argv **C.sqlite3_value) {
+	args := (*[(math.MaxInt32 - 1) / unsafe.Sizeof((*C.sqlite3_value)(nil))]*C.sqlite3_value)(unsafe.Pointer(argv))[:int(argc):int(argc)]
+	window := lookupHandle(C.sqlite3_user_data(ctx)).(*windowAggInfo)
+	window.Inverse(ctx, args)
+}
+
+//export valueTrampoline
+func valueTrampoline(ctx *C.sqlite3_context) {
+	window := lookupHandle(C.sqlite3_user_data(ctx)).(*windowAggInfo)
+	window.Value(ctx)
 }
 
 //export doneTrampoline
 func doneTrampoline(ctx *C.sqlite3_context) {
-	ai := lookupHandle(C.sqlite3_user_data(ctx)).(*aggInfo)
-	ai.Done(ctx)
+	if ai, ok := lookupHandle(C.sqlite3_user_data(ctx)).(*aggInfo); ok {
+		ai.Done(ctx)
+	}
+
+	if window, ok := lookupHandle(C.sqlite3_user_data(ctx)).(*windowAggInfo); ok {
+		window.Done(ctx)
+	}
 }
 
 //export compareTrampoline


### PR DESCRIPTION
This is a draft PR to discuss the desired interface and implementation for #1215 

I've added a new function `RegisterWindowAggregator` that is similar to (read: copy/pasted from) `RegisterAggregator`. An alternative would be to check that the interface `impl` implements the two functions that windowing requires `Inverse` and `Value`.

I'm unsure if it makes sense to use the type-embedded `windowAggInfo`, or instead to consolidate this into `aggInfo`

Once I get clarification on these two points I can make this PR more review-ready


Thanks for taking a look!