### PR TITLE
Add support for libsqlite3 on z/OS

### DIFF
--- a/sqlite3_libsqlite3.go
+++ b/sqlite3_libsqlite3.go
@@ -18,5 +18,6 @@ package sqlite3
 #cgo openbsd LDFLAGS: -lsqlite3
 #cgo solaris LDFLAGS: -lsqlite3
 #cgo windows LDFLAGS: -lsqlite3
+#cgo zos LDFLAGS: -lsqlite3
 */
 import "C"


### PR DESCRIPTION
Allows the use of the `libsqlite3` tag on z/OS