### PR TITLE
Fix memory leak in callbackRetText function

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -345,7 +345,9 @@ func callbackRetText(ctx *C.sqlite3_context, v reflect.Value) error {
 	if v.Type().Kind() != reflect.String {
 		return fmt.Errorf("cannot convert %s to TEXT", v.Type())
 	}
-	C._sqlite3_result_text(ctx, C.CString(v.Interface().(string)))
+	cstr := C.CString(v.Interface().(string))
+	defer C.free(unsafe.Pointer(cstr))
+	C._sqlite3_result_text(ctx, cstr)
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes the memory leak in the `callbackRetText` function by freeing the memory allocated by the code:
```go
C.CString(v.Interface().(string))
```