### PR TITLE
Add support for sqlite3_status64

### DIFF
--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1997,6 +1997,12 @@ func TestNamedParam(t *testing.T) {
 	}
 }
 
+func TestStatus64(t *testing.T) {
+	if _, _, err := GetStatus64(SQLITE_STATUS_MEMORY_USED, false); err != nil {
+		t.Fatal("Failed to get status64:", err)
+	}
+}
+
 var customFunctionOnce sync.Once
 
 func BenchmarkCustomFunctions(b *testing.B) {


### PR DESCRIPTION
This PR adds support for calling sqlite3_status64 from go.

See also https://github.com/mattn/go-sqlite3/issues/701#issuecomment-472708871