### PR TITLE
Update type for blob to be byte array, instead of sql.RawBytes

### DIFF
--- a/sqlite3_type.go
+++ b/sqlite3_type.go
@@ -64,7 +64,7 @@ func scanType(cdt string) reflect.Type {
 	case SQLITE_TEXT:
 		return reflect.TypeOf(sql.NullString{})
 	case SQLITE_BLOB:
-		return reflect.TypeOf(sql.RawBytes{})
+		return reflect.SliceOf(reflect.TypeOf(byte(0)))
 	case SQLITE_REAL:
 		return reflect.TypeOf(sql.NullFloat64{})
 	case SQLITE_NUMERIC:


### PR DESCRIPTION
After this PR was merged https://github.com/mattn/go-sqlite3/pull/909/files go-sqlite started return correct types for sqlite types.

However the change of type for BLOB ends up to the fact, that in GORM deserialization of byte arrays become string. The reason of this is because GORM cast all `sql.RawBytes` to strings for some reasons here https://github.com/go-gorm/gorm/blob/0daaf1747cfa4e4850376ad50a7834fb78b0cc0e/scan.go#L44
My assumption is that GORM do so, as a lot of drivers for different DBs return some good values for this sql.RawBytes. (here is example of issues raised https://github.com/go-gorm/gorm/issues/5783)

I asked question in GORM repo about this https://github.com/go-gorm/gorm/issues/7189, but some solution that can be is to change `sql.RawBytes` to `reflect.SliceOf(reflect.TypeOf(byte(0)))` (as it was before) to return BLOB as byte arrays there. This then should not introduce breaking changes nor in GORM nor in go-sqlite

