### PR TITLE
question: why do the if checks do the same thing.

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -53,10 +53,10 @@ package sqlite3
 # define USE_PREAD64 1
 # define USE_PWRITE64 1
 #elif defined(HAVE_PREAD) && defined(HAVE_PWRITE)
-# undef USE_PREAD
-# undef USE_PWRITE
-# define USE_PREAD64 1
-# define USE_PWRITE64 1
+# undef USE_PREAD64
+# undef USE_PWRITE64
+# define USE_PREAD 1
+# define USE_PWRITE 1
 #endif
 
 static int


### PR DESCRIPTION
This is more a question than an MR. Why does the macro `#if` checks do the same thing in both branches ?

Would it not make sense to have each branch do something different ?

Sorry was trying to build gogs on alpine and noticed this. (This seems to work on alpine if I try it though)