### PR TITLE
ci: fix icu4c on macos and CIFuzz test

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,7 +21,11 @@ jobs:
       GO: ${{ matrix.go }}
     steps:
       - if: startsWith(matrix.os, 'macos')
-        run: brew update
+        run: |
+          brew update
+          # Handle issues with the upgrade to icu4c v76.
+          [[ -e "$(brew --prefix)/opt/icu4c" ]] || \
+            brew reinstall icu4c
 
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Fix an issue with `icu4c` on  macos that was caused by a recent change to the formula's name and alias: https://github.com/Homebrew/homebrew-core/pull/169239#issuecomment-2448643079 and update the CIFuzz test to use V4 of the `upload-artifact` GH action.