### PR TITLE
Add ability to set an int64 file control

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1876,6 +1876,9 @@ func (c *SQLiteConn) SetLimit(id int, newVal int) int {
 // This method is not thread-safe as the returned error code can be changed by
 // another call if invoked concurrently.
 //
+// Use SetFileControlInt64 instead if the argument for the opcode is documented
+// as a pointer to a sqlite3_int64.
+//
 // See: sqlite3_file_control, https://www.sqlite.org/c3ref/file_control.html
 func (c *SQLiteConn) SetFileControlInt(dbName string, op int, arg int) error {
 	if dbName == "" {
@@ -1901,8 +1904,8 @@ func (c *SQLiteConn) SetFileControlInt(dbName string, op int, arg int) error {
 // This method is not thread-safe as the returned error code can be changed by
 // another call if invoked concurrently.
 //
-// Prefer this method over SetFileControlInt when the argument to the underlying
-// SQLite function is an int64.
+// Only use this method if the argument for the opcode is documented as a pointer
+// to a sqlite3_int64.
 //
 // See: sqlite3_file_control, https://www.sqlite.org/c3ref/file_control.html
 func (c *SQLiteConn) SetFileControlInt64(dbName string, op int, arg int64) error {

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1896,7 +1896,7 @@ func (c *SQLiteConn) SetFileControlInt(dbName string, op int, arg int) error {
 	return nil
 }
 
-// SetFileControlInt invokes the xFileControl method on a given database. The
+// SetFileControlInt64 invokes the xFileControl method on a given database. The
 // dbName is the name of the database. It will default to "main" if left blank.
 // The op is one of the opcodes prefixed by "SQLITE_FCNTL_". The arg argument
 // and return code are both opcode-specific. Please see the SQLite documentation.

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1893,6 +1893,34 @@ func (c *SQLiteConn) SetFileControlInt(dbName string, op int, arg int) error {
 	return nil
 }
 
+// SetFileControlInt invokes the xFileControl method on a given database. The
+// dbName is the name of the database. It will default to "main" if left blank.
+// The op is one of the opcodes prefixed by "SQLITE_FCNTL_". The arg argument
+// and return code are both opcode-specific. Please see the SQLite documentation.
+//
+// This method is not thread-safe as the returned error code can be changed by
+// another call if invoked concurrently.
+//
+// Prefer this method over SetFileControlInt when the argument to the underlying
+// SQLite function is an int64.
+//
+// See: sqlite3_file_control, https://www.sqlite.org/c3ref/file_control.html
+func (c *SQLiteConn) SetFileControlInt64(dbName string, op int, arg int64) error {
+	if dbName == "" {
+		dbName = "main"
+	}
+
+	cDBName := C.CString(dbName)
+	defer C.free(unsafe.Pointer(cDBName))
+
+	cArg := C.sqlite3_int64(arg)
+	rv := C.sqlite3_file_control(c.db, cDBName, C.int(op), unsafe.Pointer(&cArg))
+	if rv != C.SQLITE_OK {
+		return c.lastError()
+	}
+	return nil
+}
+
 // Close the statement.
 func (s *SQLiteStmt) Close() error {
 	s.mu.Lock()

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1882,9 +1882,6 @@ func TestSetFileControlInt64(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to open database:", err)
 		}
-		if err != nil {
-			t.Fatal("Failed to open", err)
-		}
 		err = db.Ping()
 		if err != nil {
 			t.Fatal("Failed to ping", err)

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1864,6 +1864,35 @@ func TestSetFileControlInt(t *testing.T) {
 	})
 }
 
+func TestSetFileControlInt64(t *testing.T) {
+	const GiB = 1024 * 1024 * 1024
+
+	t.Run("", func(t *testing.T) {
+
+		sql.Register("sqlite3_FCNTL_SIZE_LIMIT", &SQLiteDriver{
+			ConnectHook: func(conn *SQLiteConn) error {
+				if err := conn.SetFileControlInt64("", SQLITE_FCNTL_SIZE_LIMIT, 4*GiB); err != nil {
+					return fmt.Errorf("Unexpected error from SetFileControlInt64(): %w", err)
+				}
+				return nil
+			},
+		})
+
+		db, err := sql.Open("sqlite3", "file:/dbname?vfs=memdb")
+		if err != nil {
+			t.Fatal("Failed to open database:", err)
+		}
+		if err != nil {
+			t.Fatal("Failed to open", err)
+		}
+		err = db.Ping()
+		if err != nil {
+			t.Fatal("Failed to ping", err)
+		}
+		db.Close()
+	})
+}
+
 func TestNonColumnString(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {


### PR DESCRIPTION
Similar to https://github.com/mattn/go-sqlite3/pull/1000,

We are using `vfs=memdb` and would like to use the `SQLITE_FCNTL_SIZE_LIMIT` opcode with `sqlite3_file_control`:

> The [SQLITE_FCNTL_SIZE_LIMIT](https://www.sqlite.org/c3ref/c_fcntl_begin_atomic_write.html#sqlitefcntlsizelimit) opcode is used by in-memory VFS that implements [sqlite3_deserialize()](https://www.sqlite.org/c3ref/deserialize.html) to set an upper bound on the size of the in-memory database. The argument is a pointer to a [sqlite3_int64](https://www.sqlite.org/c3ref/int64.html). If the integer pointed to is negative, then it is filled in with the current limit. Otherwise the limit is set to the larger of the value of the integer pointed to and the current database size. The integer pointed to is set to the new limit.

Calling the existing `SetFileControlInt` method when go decides that `int`s are `int64` based on your architecture seem to overflow the `C.int` and in our case set the size limit of our in-memory VFS to 0. This adds a new `SetFileControlInt64` to be used with op codes that expect a `sqlite3_int64`.