### PR TITLE
Upgrade upload-artifact action

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -22,7 +22,7 @@ jobs:
        dry-run: false
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      if: failure()
      with:
        name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
On #1298, the [fuzzing action failed to run](https://github.com/mattn/go-sqlite3/actions/runs/12014833442/job/33492262820) 

![image](https://github.com/user-attachments/assets/f471140c-92bd-42dc-946f-481107c6f43a)


action/upload-artifact@v1 has been deprecated for a while. It seems like GitHub Actions will now cancel workflows if it is still using v1 of the action. This upgrades to the latest v4 of the action.

See https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/ for details.