### PR TITLE
docs: clarify GCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This package follows the official [Golang Release Policy](https://golang.org/doc
   - [Android](#android)
 - [ARM](#arm)
 - [Cross Compile](#cross-compile)
-- [Google Cloud Platform](#google-cloud-platform)
+- [Compiling](#compiling)
   - [Linux](#linux)
     - [Alpine](#alpine)
     - [Fedora](#fedora)
@@ -227,11 +227,7 @@ Steps:
 
 Please refer to the project's [README](https://github.com/FiloSottile/homebrew-musl-cross#readme) for further information.
 
-# Google Cloud Platform
-
-Building on GCP is not possible because Google Cloud Platform does not allow `gcc` to be executed.
-
-Please work only with compiled final binaries.
+# Compiling
 
 ## Linux
 


### PR DESCRIPTION
GCP (at least Google Compute Engine) is a VM, and does not have restrictions relating to gcc.

Also it appears that this whole section refers to general compiling, rather than compiling on GCP.
