### PR TITLE
Fix #1316: Example vtable_eponymous_only misses start value assignment to cursor

### DIFF
--- a/_example/vtable_eponymous_only/vtable.go
+++ b/_example/vtable_eponymous_only/vtable.go
@@ -95,6 +95,7 @@ func (vc *seriesCursor) Filter(idxNum int, idxStr string, vals []any) error {
 		vc.seriesTable.start = vals[0].(int64)
 		vc.seriesTable.stop = vals[1].(int64)
 		vc.seriesTable.step = vals[2].(int64)
+		vc.value = vc.seriesTable.start
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes issue #1316.