### PR TITLE
Add sqlite_dbpage extension build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ go build -tags "icu json1 fts5 secure_delete"
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
 | Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/mattn/go-sqlite3/tree/master/_example/vtable) |
+| SQLITE_DBPAGE Virtual Table | sqlite_dbpage | SQLITE_DBPAGE Virtual Table see [SQLite Official SQLITE_DBPAGE Documentation](https://www.sqlite.org/dbpage.html) for more information. |
 
 # Compilation
 

--- a/sqlite3_opt_dbpage.go
+++ b/sqlite3_opt_dbpage.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build sqlite_dbpage
+// +build sqlite_dbpage
+
+package sqlite3
+
+/*
+#cgo CFLAGS: -DSQLITE_ENABLE_DBPAGE_VTAB
+#cgo LDFLAGS: -lm
+*/
+import "C"


### PR DESCRIPTION
Provides raw access to database pages. Useful for taking consistent live snapshots of WAL databases without causing write locks by reading out all of the pages and writing them either to a file or some external storage.

The [sqlite3_rsync](https://www.sqlite.org/rsync.html) utility that is bundled with sqlite3 source is one way to use it to somewhat efficiently synchronize a remote database.