### PR TITLE
Add columns used to BestIndex callback, add missing index constraint op types.

### DIFF
--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -62,7 +62,7 @@ func (v *ghRepoTable) Open() (sqlite3.VTabCursor, error) {
 	return &ghRepoCursor{0, repos}, nil
 }
 
-func (v *ghRepoTable) BestIndex(csts []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
+func (v *ghRepoTable) BestIndex(csts []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, colsUsed uint64) (*sqlite3.IndexResult, error) {
 	used := make([]bool, len(csts))
 	return &sqlite3.IndexResult{
 		IdxNum: 0,

--- a/_example/vtable_eponymous_only/vtable.go
+++ b/_example/vtable_eponymous_only/vtable.go
@@ -40,7 +40,7 @@ func (v *seriesTable) Open() (sqlite3.VTabCursor, error) {
 	return &seriesCursor{v, 0}, nil
 }
 
-func (v *seriesTable) BestIndex(csts []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
+func (v *seriesTable) BestIndex(csts []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, colsUsed uint64) (*sqlite3.IndexResult, error) {
 	used := make([]bool, len(csts))
 	for c, cst := range csts {
 		if cst.Usable && cst.Op == sqlite3.OpEQ {

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -448,7 +448,7 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 	vt := lookupHandle(pVTab).(*sqliteVTab)
 	info := (*C.sqlite3_index_info)(icp)
 	csts := constraints(info)
-	res, err := vt.vTab.BestIndex(csts, orderBys(info))
+	res, err := vt.vTab.BestIndex(csts, orderBys(info), uint64(info.colUsed))
 	if err != nil {
 		return mPrintf("%s", err.Error())
 	}
@@ -650,7 +650,7 @@ type EponymousOnlyModule interface {
 // See: http://sqlite.org/c3ref/vtab.html
 type VTab interface {
 	// http://sqlite.org/vtab.html#xbestindex
-	BestIndex([]InfoConstraint, []InfoOrderBy) (*IndexResult, error)
+	BestIndex([]InfoConstraint, []InfoOrderBy, uint64) (*IndexResult, error)
 	// http://sqlite.org/vtab.html#xdisconnect
 	Disconnect() error
 	// http://sqlite.org/vtab.html#sqlite3_module.xDestroy

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -301,10 +301,18 @@ const (
 	OpLT            = 16
 	OpGE            = 32
 	OpMATCH         = 64
-	OpLIKE          = 65 /* 3.10.0 and later only */
-	OpGLOB          = 66 /* 3.10.0 and later only */
-	OpREGEXP        = 67 /* 3.10.0 and later only */
-	OpScanUnique    = 1  /* Scan visits at most 1 row */
+	OpLIKE          = 65  /* 3.10.0 and later only */
+	OpGLOB          = 66  /* 3.10.0 and later only */
+	OpREGEXP        = 67  /* 3.10.0 and later only */
+	OpNE            = 68  /* 3.21.0 and later only */
+	OpISNOT         = 69  /* 3.21.0 and later */
+	OpISNOTNULL     = 70  /* 3.21.0 and later */
+	OpISNULL        = 71  /* 3.21.0 and later */
+	OpIS            = 72  /* 3.21.0 and later */
+	OpLIMIT         = 73  /* 3.38.0 and later */
+	OpOFFSET        = 74  /* 3.38.0 and later */
+	OpFUNCTION      = 150 /* 3.25.0 and later */
+	OpScanUnique    = 1   /* Scan visits at most 1 row */
 )
 
 // InfoConstraint give information of constraint.

--- a/sqlite3_opt_vtable_test.go
+++ b/sqlite3_opt_vtable_test.go
@@ -67,7 +67,7 @@ func (m testModule) Connect(c *SQLiteConn, args []string) (VTab, error) {
 
 func (m testModule) DestroyModule() {}
 
-func (v *testVTab) BestIndex(cst []InfoConstraint, ob []InfoOrderBy) (*IndexResult, error) {
+func (v *testVTab) BestIndex(cst []InfoConstraint, ob []InfoOrderBy, colsUsed uint64) (*IndexResult, error) {
 	used := make([]bool, 0, len(cst))
 	for range cst {
 		used = append(used, false)
@@ -377,7 +377,7 @@ func (t *vtabUpdateTable) Open() (VTabCursor, error) {
 	return &vtabUpdateCursor{t, 0}, nil
 }
 
-func (t *vtabUpdateTable) BestIndex(cst []InfoConstraint, ob []InfoOrderBy) (*IndexResult, error) {
+func (t *vtabUpdateTable) BestIndex(cst []InfoConstraint, ob []InfoOrderBy, colsUsed uint64) (*IndexResult, error) {
 	return &IndexResult{Used: make([]bool, len(cst))}, nil
 }
 
@@ -516,7 +516,7 @@ func (m testModuleEponymousOnly) Connect(c *SQLiteConn, args []string) (VTab, er
 
 func (m testModuleEponymousOnly) DestroyModule() {}
 
-func (v *testVTabEponymousOnly) BestIndex(cst []InfoConstraint, ob []InfoOrderBy) (*IndexResult, error) {
+func (v *testVTabEponymousOnly) BestIndex(cst []InfoConstraint, ob []InfoOrderBy, colsUsed uint64) (*IndexResult, error) {
 	used := make([]bool, 0, len(cst))
 	for range cst {
 		used = append(used, false)


### PR DESCRIPTION
Fixes mattn/go-sqlite3#1322, fixes mattn/go-sqlite3#1323