### PR TITLE
add sqlite_dbstat tag for the DBSTAT virtual table

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ go build -tags "icu json1 fts5 secure_delete"
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
 | Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/mattn/go-sqlite3/tree/master/_example/vtable) |
+| The DBSTAT Virtual Table | sqlite_dbstat | The DBSTAT virtual table is a read-only virtual table that returns information about the amount of disk space used to store the content of an SQLite database. See [SQLite Official Documentation](https://www.sqlite.org/dbstat.html) for more information. |
 
 # Compilation
 

--- a/sqlite3_opt_dbstat.go
+++ b/sqlite3_opt_dbstat.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2025 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+// Copyright (C) 2025 Jakob Borg <jakob@kastelo.net>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build sqlite_dbstat
+// +build sqlite_dbstat
+
+package sqlite3
+
+/*
+#cgo CFLAGS: -DSQLITE_ENABLE_DBSTAT_VTAB
+*/
+import "C"


### PR DESCRIPTION
Used to gather statistics information about table disk usage.