### PR TITLE
evict least-recently-used stmt when cache is full

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1934,9 +1934,11 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 		copy(c.stmtCache[i:n-1], c.stmtCache[i+1:n])
 		c.stmtCache[n-1] = nil
 		c.stmtCache = c.stmtCache[:n-1]
+		// The stmt was marked closed by Close before being cached, and
+		// cls may have been set if Query opened it; reset both so the
+		// caller gets a stmt equivalent to a fresh Prepare.
 		s.closed = false
 		s.cls = false
-		s.t = ""
 		return s
 	}
 	return nil
@@ -1960,14 +1962,7 @@ func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
 	// If full, finalize the LRU entry at index 0 and shift left; the
 	// freed tail slot is immediately reused by the append below.
 	if len(c.stmtCache) == cap(c.stmtCache) {
-		victim := c.stmtCache[0]
-		runtime.SetFinalizer(victim, nil)
-		if victim.s != nil {
-			C.sqlite3_finalize(victim.s)
-			victim.s = nil
-		}
-		victim.c = nil
-		victim.closed = true
+		finalizeCachedStmt(c.stmtCache[0])
 		copy(c.stmtCache, c.stmtCache[1:])
 		c.stmtCache = c.stmtCache[:len(c.stmtCache)-1]
 	}
@@ -1978,15 +1973,25 @@ func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
 func (c *SQLiteConn) closeCachedStmtsLocked() {
 	for i, s := range c.stmtCache {
 		c.stmtCache[i] = nil
-		if s == nil || s.s == nil {
-			continue
-		}
-		runtime.SetFinalizer(s, nil)
-		C.sqlite3_finalize(s.s)
-		s.s = nil
-		s.c = nil
+		finalizeCachedStmt(s)
 	}
 	c.stmtCache = c.stmtCache[:0]
+}
+
+// finalizeCachedStmt tears down a stmt that was sitting in the connection's
+// stmt cache. The caller must hold c.mu. It is safe to pass a nil stmt or a
+// stmt whose handle has already been released.
+func finalizeCachedStmt(s *SQLiteStmt) {
+	if s == nil {
+		return
+	}
+	runtime.SetFinalizer(s, nil)
+	if s.s != nil {
+		C.sqlite3_finalize(s.s)
+		s.s = nil
+	}
+	s.c = nil
+	s.closed = true
 }
 
 // Prepare the query string. Return a new statement.

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -451,15 +451,14 @@ type SQLiteConn struct {
 	txlock         string
 	funcs          []*functionInfo
 	aggregators    []*aggInfo
-	// Prepared-statement cache. stmtCacheBuf is a preallocated slice of
-	// length stmtCacheSize holding up to stmtCacheCount live entries at
-	// indices [0, stmtCacheCount). Ordering is LRU-first: index 0 is the
-	// oldest (next to be evicted), index stmtCacheCount-1 is the most
-	// recently put. put at the tail is O(1) when not full; eviction shifts
-	// the remaining entries left by one.
-	stmtCacheBuf   []*SQLiteStmt
-	stmtCacheSize  int
-	stmtCacheCount int
+	// Prepared-statement cache. The slice is allocated at Open with a
+	// fixed capacity equal to the configured cache size; cap bounds the
+	// cache, len is the live count, and entries are ordered LRU-first
+	// (index 0 is the oldest, the tail is most recently put). Access
+	// requires mu; stmtCacheEnabled is immutable after Open and is the
+	// only field safe to read without the lock.
+	stmtCache        []*SQLiteStmt
+	stmtCacheEnabled bool
 }
 
 // SQLiteTx implements driver.Tx.
@@ -1617,9 +1616,10 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	//
 
 	// Create connection to SQLite
-	conn := &SQLiteConn{db: db, loc: loc, txlock: txlock, stmtCacheSize: stmtCacheSize}
+	conn := &SQLiteConn{db: db, loc: loc, txlock: txlock}
 	if stmtCacheSize > 0 {
-		conn.stmtCacheBuf = make([]*SQLiteStmt, stmtCacheSize)
+		conn.stmtCache = make([]*SQLiteStmt, 0, stmtCacheSize)
+		conn.stmtCacheEnabled = true
 	}
 
 	// Password Cipher has to be registered before authentication
@@ -1913,7 +1913,7 @@ func (c *SQLiteConn) dbConnOpen() bool {
 }
 
 func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
-	if c == nil || query == "" || c.stmtCacheSize <= 0 {
+	if c == nil || query == "" || !c.stmtCacheEnabled {
 		return nil
 	}
 
@@ -1925,17 +1925,15 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 	}
 	// Scan from the MRU end (tail) so that a stmt put just before is
 	// found immediately.
-	for i := c.stmtCacheCount - 1; i >= 0; i-- {
-		s := c.stmtCacheBuf[i]
+	for i := len(c.stmtCache) - 1; i >= 0; i-- {
+		s := c.stmtCache[i]
 		if s.cacheKey != query {
 			continue
 		}
-		// Remove s from the buffer by shifting subsequent entries left.
-		if i != c.stmtCacheCount-1 {
-			copy(c.stmtCacheBuf[i:c.stmtCacheCount-1], c.stmtCacheBuf[i+1:c.stmtCacheCount])
-		}
-		c.stmtCacheCount--
-		c.stmtCacheBuf[c.stmtCacheCount] = nil
+		n := len(c.stmtCache)
+		copy(c.stmtCache[i:n-1], c.stmtCache[i+1:n])
+		c.stmtCache[n-1] = nil
+		c.stmtCache = c.stmtCache[:n-1]
 		s.closed = false
 		s.cls = false
 		s.t = ""
@@ -1945,7 +1943,7 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 }
 
 func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
-	if c == nil || s == nil || s.s == nil || s.cacheKey == "" || c.stmtCacheSize <= 0 {
+	if c == nil || s == nil || s.s == nil || s.cacheKey == "" || !c.stmtCacheEnabled {
 		return false
 	}
 
@@ -1959,10 +1957,10 @@ func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
 		return false
 	}
-	// If full, finalize the least-recently-used entry at index 0 and
-	// compact the remaining entries left by one.
-	if c.stmtCacheCount == c.stmtCacheSize {
-		victim := c.stmtCacheBuf[0]
+	// If full, finalize the LRU entry at index 0 and shift left; the
+	// freed tail slot is immediately reused by the append below.
+	if len(c.stmtCache) == cap(c.stmtCache) {
+		victim := c.stmtCache[0]
 		runtime.SetFinalizer(victim, nil)
 		if victim.s != nil {
 			C.sqlite3_finalize(victim.s)
@@ -1970,19 +1968,16 @@ func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
 		}
 		victim.c = nil
 		victim.closed = true
-		copy(c.stmtCacheBuf[0:c.stmtCacheCount-1], c.stmtCacheBuf[1:c.stmtCacheCount])
-		c.stmtCacheCount--
+		copy(c.stmtCache, c.stmtCache[1:])
+		c.stmtCache = c.stmtCache[:len(c.stmtCache)-1]
 	}
-	// Append at the MRU tail.
-	c.stmtCacheBuf[c.stmtCacheCount] = s
-	c.stmtCacheCount++
+	c.stmtCache = append(c.stmtCache, s)
 	return true
 }
 
 func (c *SQLiteConn) closeCachedStmtsLocked() {
-	for i := 0; i < c.stmtCacheCount; i++ {
-		s := c.stmtCacheBuf[i]
-		c.stmtCacheBuf[i] = nil
+	for i, s := range c.stmtCache {
+		c.stmtCache[i] = nil
 		if s == nil || s.s == nil {
 			continue
 		}
@@ -1991,7 +1986,7 @@ func (c *SQLiteConn) closeCachedStmtsLocked() {
 		s.s = nil
 		s.c = nil
 	}
-	c.stmtCacheCount = 0
+	c.stmtCache = c.stmtCache[:0]
 }
 
 // Prepare the query string. Return a new statement.

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1943,7 +1943,7 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 }
 
 func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
-	if c == nil || s == nil || s.s == nil || s.cacheKey == "" || !c.stmtCacheEnabled {
+	if c == nil || s == nil || s.s == nil || s.cacheKey == "" {
 		return false
 	}
 
@@ -2021,7 +2021,7 @@ func (c *SQLiteConn) prepareWithCache(ctx context.Context, query string) (driver
 		return nil, err
 	}
 	ss := stmt.(*SQLiteStmt)
-	if ss.t == "" {
+	if ss.t == "" && c.stmtCacheEnabled {
 		ss.cacheKey = query
 	}
 	return ss, nil

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -451,7 +451,13 @@ type SQLiteConn struct {
 	txlock         string
 	funcs          []*functionInfo
 	aggregators    []*aggInfo
-	stmtCache      map[string][]*SQLiteStmt
+	// Prepared-statement cache. stmtCacheBuf is a preallocated slice of
+	// length stmtCacheSize holding up to stmtCacheCount live entries at
+	// indices [0, stmtCacheCount). Ordering is LRU-first: index 0 is the
+	// oldest (next to be evicted), index stmtCacheCount-1 is the most
+	// recently put. put at the tail is O(1) when not full; eviction shifts
+	// the remaining entries left by one.
+	stmtCacheBuf   []*SQLiteStmt
 	stmtCacheSize  int
 	stmtCacheCount int
 }
@@ -1613,7 +1619,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	// Create connection to SQLite
 	conn := &SQLiteConn{db: db, loc: loc, txlock: txlock, stmtCacheSize: stmtCacheSize}
 	if stmtCacheSize > 0 {
-		conn.stmtCache = make(map[string][]*SQLiteStmt)
+		conn.stmtCacheBuf = make([]*SQLiteStmt, stmtCacheSize)
 	}
 
 	// Password Cipher has to be registered before authentication
@@ -1917,55 +1923,73 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 	if c.db == nil {
 		return nil
 	}
-	stmts := c.stmtCache[query]
-	if len(stmts) == 0 {
-		return nil
+	// Scan from the MRU end (tail) so that a stmt put just before is
+	// found immediately.
+	for i := c.stmtCacheCount - 1; i >= 0; i-- {
+		s := c.stmtCacheBuf[i]
+		if s.cacheKey != query {
+			continue
+		}
+		// Remove s from the buffer by shifting subsequent entries left.
+		if i != c.stmtCacheCount-1 {
+			copy(c.stmtCacheBuf[i:c.stmtCacheCount-1], c.stmtCacheBuf[i+1:c.stmtCacheCount])
+		}
+		c.stmtCacheCount--
+		c.stmtCacheBuf[c.stmtCacheCount] = nil
+		s.closed = false
+		s.cls = false
+		s.t = ""
+		return s
 	}
-	s := stmts[len(stmts)-1]
-	if len(stmts) == 1 {
-		delete(c.stmtCache, query)
-	} else {
-		c.stmtCache[query] = stmts[:len(stmts)-1]
-	}
-	c.stmtCacheCount--
-	s.closed = false
-	s.cls = false
-	s.t = ""
-	return s
+	return nil
 }
 
 func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
-	if c == nil || s == nil || s.s == nil || s.cacheKey == "" {
+	if c == nil || s == nil || s.s == nil || s.cacheKey == "" || c.stmtCacheSize <= 0 {
 		return false
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.db == nil || c.stmtCacheCount >= c.stmtCacheSize {
+	if c.db == nil {
 		return false
 	}
 	rv := C._sqlite3_reset_clear(s.s)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
 		return false
 	}
-	c.stmtCache[s.cacheKey] = append(c.stmtCache[s.cacheKey], s)
+	// If full, finalize the least-recently-used entry at index 0 and
+	// compact the remaining entries left by one.
+	if c.stmtCacheCount == c.stmtCacheSize {
+		victim := c.stmtCacheBuf[0]
+		runtime.SetFinalizer(victim, nil)
+		if victim.s != nil {
+			C.sqlite3_finalize(victim.s)
+			victim.s = nil
+		}
+		victim.c = nil
+		victim.closed = true
+		copy(c.stmtCacheBuf[0:c.stmtCacheCount-1], c.stmtCacheBuf[1:c.stmtCacheCount])
+		c.stmtCacheCount--
+	}
+	// Append at the MRU tail.
+	c.stmtCacheBuf[c.stmtCacheCount] = s
 	c.stmtCacheCount++
 	return true
 }
 
 func (c *SQLiteConn) closeCachedStmtsLocked() {
-	for key, stmts := range c.stmtCache {
-		for _, s := range stmts {
-			if s == nil || s.s == nil {
-				continue
-			}
-			runtime.SetFinalizer(s, nil)
-			C.sqlite3_finalize(s.s)
-			s.s = nil
-			s.c = nil
+	for i := 0; i < c.stmtCacheCount; i++ {
+		s := c.stmtCacheBuf[i]
+		c.stmtCacheBuf[i] = nil
+		if s == nil || s.s == nil {
+			continue
 		}
-		delete(c.stmtCache, key)
+		runtime.SetFinalizer(s, nil)
+		C.sqlite3_finalize(s.s)
+		s.s = nil
+		s.c = nil
 	}
 	c.stmtCacheCount = 0
 }

--- a/sqlite3_stmt_cache_bench_test.go
+++ b/sqlite3_stmt_cache_bench_test.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build cgo
+// +build cgo
+
+package sqlite3
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkStmtCache measures the stmt cache hit / miss / eviction paths by
+// cycling through a fixed set of queries under various cache sizes. It is
+// intended for comparing cache behavior changes, not for absolute numbers.
+func BenchmarkStmtCache(b *testing.B) {
+	cases := []struct {
+		name      string
+		cacheSize int
+		keyCount  int
+	}{
+		{"off", 0, 1},                 // baseline: no cache
+		{"size4_keys1_hit", 4, 1},     // trivial hit path
+		{"size4_keys4_hit", 4, 4},     // all queries fit, always hit
+		{"size4_keys8_evict", 4, 8},   // working set > cache: miss + eviction
+		{"size16_keys8_hit", 16, 8},   // all queries fit in larger cache
+		{"size16_keys32_evict", 16, 32}, // working set >> cache
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			dsn := ":memory:"
+			if tc.cacheSize > 0 {
+				dsn = fmt.Sprintf(":memory:?_stmt_cache_size=%d", tc.cacheSize)
+			}
+			d := SQLiteDriver{}
+			conn, err := d.Open(dsn)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer conn.Close()
+			c := conn.(*SQLiteConn)
+
+			queries := make([]string, tc.keyCount)
+			for i := range queries {
+				// Distinct literal forces a distinct prepared statement.
+				queries[i] = fmt.Sprintf("SELECT %d", i+1)
+			}
+
+			ctx := context.Background()
+			// Warm up: exercise each query at least once so the cache (if any)
+			// reaches steady state before timing begins.
+			for _, q := range queries {
+				rows, err := c.query(ctx, q, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				drainRows(b, rows)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				q := queries[i%len(queries)]
+				rows, err := c.query(ctx, q, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				drainRows(b, rows)
+			}
+		})
+	}
+}
+
+func drainRows(b *testing.B, rows driver.Rows) {
+	b.Helper()
+	dest := make([]driver.Value, len(rows.Columns()))
+	for {
+		if err := rows.Next(dest); err != nil {
+			break
+		}
+	}
+	rows.Close()
+}

--- a/sqlite3_stmt_cache_test.go
+++ b/sqlite3_stmt_cache_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2019 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build cgo
+// +build cgo
+
+package sqlite3
+
+import (
+	"context"
+	"testing"
+)
+
+// TestStmtCacheLRUEviction verifies that when the prepared-statement cache is
+// full, the least-recently-used entry is evicted to make room for a new one.
+// Without eviction, the first N queries to enter the cache would squat on
+// every slot forever and any subsequently-prepared query (even a hot one)
+// would never benefit from caching.
+func TestStmtCacheLRUEviction(t *testing.T) {
+	d := SQLiteDriver{}
+	conn, err := d.Open(":memory:?_stmt_cache_size=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := conn.(*SQLiteConn)
+	ctx := context.Background()
+
+	prepareAndClose := func(q string) {
+		t.Helper()
+		stmt, err := c.prepareWithCache(ctx, q)
+		if err != nil {
+			t.Fatalf("prepareWithCache(%q): %v", q, err)
+		}
+		if err := stmt.Close(); err != nil {
+			t.Fatalf("Close(%q): %v", q, err)
+		}
+	}
+
+	q1 := "SELECT 1"
+	q2 := "SELECT 2"
+	q3 := "SELECT 3"
+
+	// Fill the cache with q1 and q2.
+	prepareAndClose(q1)
+	prepareAndClose(q2)
+	if got, want := c.stmtCacheCount, 2; got != want {
+		t.Fatalf("after filling: stmtCacheCount = %d, want %d", got, want)
+	}
+	if cacheCount(c, q1) != 1 || cacheCount(c, q2) != 1 {
+		t.Fatalf("after filling: expected q1 and q2 cached, got %#v", cacheKeys(c))
+	}
+
+	// Insert q3. q1 is the oldest entry and should be evicted.
+	prepareAndClose(q3)
+	if got, want := c.stmtCacheCount, 2; got != want {
+		t.Fatalf("after q3: stmtCacheCount = %d, want %d", got, want)
+	}
+	if cacheCount(c, q1) != 0 {
+		t.Fatalf("after q3: q1 should have been evicted, cache=%#v", cacheKeys(c))
+	}
+	if cacheCount(c, q2) != 1 || cacheCount(c, q3) != 1 {
+		t.Fatalf("after q3: expected q2 and q3 cached, got %#v", cacheKeys(c))
+	}
+
+	// Touching q2 should make q3 the oldest (the entry at buf[0]).
+	prepareAndClose(q2)
+	if c.stmtCacheCount == 0 || c.stmtCacheBuf[0].cacheKey != q3 {
+		var head string
+		if c.stmtCacheCount > 0 {
+			head = c.stmtCacheBuf[0].cacheKey
+		}
+		t.Fatalf("after touching q2: expected q3 at buf[0] (LRU), got %q", head)
+	}
+
+	// Insert q1 again. Now q3 should be evicted (q2 is newer).
+	prepareAndClose(q1)
+	if cacheCount(c, q3) != 0 {
+		t.Fatalf("after reinserting q1: q3 should have been evicted, cache=%#v", cacheKeys(c))
+	}
+	if cacheCount(c, q1) != 1 || cacheCount(c, q2) != 1 {
+		t.Fatalf("after reinserting q1: expected q1 and q2 cached, got %#v", cacheKeys(c))
+	}
+	if got, want := c.stmtCacheCount, 2; got != want {
+		t.Fatalf("after reinserting q1: stmtCacheCount = %d, want %d", got, want)
+	}
+
+	// Sanity-check: no dangling entries past stmtCacheCount.
+	for i := c.stmtCacheCount; i < len(c.stmtCacheBuf); i++ {
+		if c.stmtCacheBuf[i] != nil {
+			t.Fatalf("stmtCacheBuf[%d] = %p, expected nil tail slot", i, c.stmtCacheBuf[i])
+		}
+	}
+}
+
+// TestStmtCacheReuseReturnsSameHandle verifies that a cached prepare reuses
+// the underlying sqlite3_stmt rather than preparing a fresh one.
+func TestStmtCacheReuseReturnsSameHandle(t *testing.T) {
+	d := SQLiteDriver{}
+	conn, err := d.Open(":memory:?_stmt_cache_size=4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := conn.(*SQLiteConn)
+	ctx := context.Background()
+
+	const q = "SELECT 42"
+	stmt1, err := c.prepareWithCache(ctx, q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1 := stmt1.(*SQLiteStmt).s
+	if err := stmt1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stmt2, err := c.prepareWithCache(ctx, q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2 := stmt2.(*SQLiteStmt).s
+	if err := stmt2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if h1 != h2 {
+		t.Fatalf("expected cached prepare to reuse sqlite3_stmt handle, got %p vs %p", h1, h2)
+	}
+}
+
+func cacheKeys(c *SQLiteConn) map[string]int {
+	out := make(map[string]int)
+	for i := 0; i < c.stmtCacheCount; i++ {
+		out[c.stmtCacheBuf[i].cacheKey]++
+	}
+	return out
+}
+
+func cacheCount(c *SQLiteConn, q string) int {
+	n := 0
+	for i := 0; i < c.stmtCacheCount; i++ {
+		if c.stmtCacheBuf[i].cacheKey == q {
+			n++
+		}
+	}
+	return n
+}

--- a/sqlite3_stmt_cache_test.go
+++ b/sqlite3_stmt_cache_test.go
@@ -47,8 +47,8 @@ func TestStmtCacheLRUEviction(t *testing.T) {
 	// Fill the cache with q1 and q2.
 	prepareAndClose(q1)
 	prepareAndClose(q2)
-	if got, want := c.stmtCacheCount, 2; got != want {
-		t.Fatalf("after filling: stmtCacheCount = %d, want %d", got, want)
+	if got, want := len(c.stmtCache), 2; got != want {
+		t.Fatalf("after filling: len(stmtCache) = %d, want %d", got, want)
 	}
 	if cacheCount(c, q1) != 1 || cacheCount(c, q2) != 1 {
 		t.Fatalf("after filling: expected q1 and q2 cached, got %#v", cacheKeys(c))
@@ -56,8 +56,8 @@ func TestStmtCacheLRUEviction(t *testing.T) {
 
 	// Insert q3. q1 is the oldest entry and should be evicted.
 	prepareAndClose(q3)
-	if got, want := c.stmtCacheCount, 2; got != want {
-		t.Fatalf("after q3: stmtCacheCount = %d, want %d", got, want)
+	if got, want := len(c.stmtCache), 2; got != want {
+		t.Fatalf("after q3: len(stmtCache) = %d, want %d", got, want)
 	}
 	if cacheCount(c, q1) != 0 {
 		t.Fatalf("after q3: q1 should have been evicted, cache=%#v", cacheKeys(c))
@@ -66,14 +66,14 @@ func TestStmtCacheLRUEviction(t *testing.T) {
 		t.Fatalf("after q3: expected q2 and q3 cached, got %#v", cacheKeys(c))
 	}
 
-	// Touching q2 should make q3 the oldest (the entry at buf[0]).
+	// Touching q2 should make q3 the oldest (the entry at index 0).
 	prepareAndClose(q2)
-	if c.stmtCacheCount == 0 || c.stmtCacheBuf[0].cacheKey != q3 {
+	if len(c.stmtCache) == 0 || c.stmtCache[0].cacheKey != q3 {
 		var head string
-		if c.stmtCacheCount > 0 {
-			head = c.stmtCacheBuf[0].cacheKey
+		if len(c.stmtCache) > 0 {
+			head = c.stmtCache[0].cacheKey
 		}
-		t.Fatalf("after touching q2: expected q3 at buf[0] (LRU), got %q", head)
+		t.Fatalf("after touching q2: expected q3 at stmtCache[0] (LRU), got %q", head)
 	}
 
 	// Insert q1 again. Now q3 should be evicted (q2 is newer).
@@ -84,14 +84,15 @@ func TestStmtCacheLRUEviction(t *testing.T) {
 	if cacheCount(c, q1) != 1 || cacheCount(c, q2) != 1 {
 		t.Fatalf("after reinserting q1: expected q1 and q2 cached, got %#v", cacheKeys(c))
 	}
-	if got, want := c.stmtCacheCount, 2; got != want {
-		t.Fatalf("after reinserting q1: stmtCacheCount = %d, want %d", got, want)
+	if got, want := len(c.stmtCache), 2; got != want {
+		t.Fatalf("after reinserting q1: len(stmtCache) = %d, want %d", got, want)
 	}
 
-	// Sanity-check: no dangling entries past stmtCacheCount.
-	for i := c.stmtCacheCount; i < len(c.stmtCacheBuf); i++ {
-		if c.stmtCacheBuf[i] != nil {
-			t.Fatalf("stmtCacheBuf[%d] = %p, expected nil tail slot", i, c.stmtCacheBuf[i])
+	// Sanity-check: no dangling entries past len(stmtCache).
+	tail := c.stmtCache[:cap(c.stmtCache)]
+	for i := len(c.stmtCache); i < len(tail); i++ {
+		if tail[i] != nil {
+			t.Fatalf("stmtCache tail slot %d = %p, expected nil", i, tail[i])
 		}
 	}
 }
@@ -135,16 +136,16 @@ func TestStmtCacheReuseReturnsSameHandle(t *testing.T) {
 
 func cacheKeys(c *SQLiteConn) map[string]int {
 	out := make(map[string]int)
-	for i := 0; i < c.stmtCacheCount; i++ {
-		out[c.stmtCacheBuf[i].cacheKey]++
+	for _, s := range c.stmtCache {
+		out[s.cacheKey]++
 	}
 	return out
 }
 
 func cacheCount(c *SQLiteConn, q string) int {
 	n := 0
-	for i := 0; i < c.stmtCacheCount; i++ {
-		if c.stmtCacheBuf[i].cacheKey == q {
+	for _, s := range c.stmtCache {
+		if s.cacheKey == q {
 			n++
 		}
 	}


### PR DESCRIPTION
Follow-up to #1387, addressing rittneje's comment: https://github.com/mattn/go-sqlite3/pull/1387#issuecomment-4210592706

When the cache was full, `putCachedStmt` rejected the new entry instead of evicting anything. This meant the first N cached statements squatted on every slot forever, and a hot query prepared later would never benefit from caching. Now we evict the least-recently-used entry to make room.

The cache is a single preallocated `[]*SQLiteStmt` of length `_stmt_cache_size`, ordered LRU-first (`buf[0]` is next to be evicted, `buf[count-1]` is the most recently put). Put at the tail is O(1) when not full; eviction shifts the remaining entries left by one. Take does a backward linear scan (MRU-end first) and shifts the right side left. For the small cache sizes users typically configure (a handful up to a few dozen), these O(N) operations are cache-friendly pointer moves and outperform the previous map + linked list design on every hit-path microbenchmark.

No per-operation allocation, no map, no linked list, no extra fields on `SQLiteStmt`.

## Benchmarks

`BenchmarkStmtCache` is added in this PR. Measured on linux/amd64, AMD Ryzen 7 7735HS, `benchstat` over 10 runs.

### vs master (before this PR)

```
                                 │   master    │             this PR              │
                                 │   sec/op    │   sec/op     vs base              │
StmtCache/off                      2.194µ ± 3%   2.234µ ± 2%   +1.85% (p=0.005)
StmtCache/size4_keys1_hit          1.163µ ± 2%   1.127µ ± 3%   -3.10% (p=0.005)
StmtCache/size4_keys4_hit          1.173µ ± 7%   1.158µ ± 6%        ~ (p=0.956)
StmtCache/size16_keys8_hit         1.183µ ± 2%   1.146µ ± 4%        ~ (p=0.165)
StmtCache/size4_keys8_evict        1.762µ ± 2%   2.459µ ± 4%  +39.53% (p=0.000)
StmtCache/size16_keys32_evict      1.798µ ± 6%   2.663µ ± 4%  +48.11% (p=0.000)
```

```
                                 │   master    │          this PR           │
                                 │  allocs/op  │ allocs/op   vs base        │
StmtCache/size4_keys1_hit            6.000 ± 0%   5.000 ± 0%  -16.67%
StmtCache/size4_keys4_hit            6.000 ± 0%   5.000 ± 0%  -16.67%
StmtCache/size16_keys8_hit           6.000 ± 0%   5.000 ± 0%  -16.67%
```

### Interpretation

**Hit path (working set fits in cache).** All three hit cases come out faster than master or within noise, with one fewer allocation per operation. Replacing the previous `map[string][]*SQLiteStmt` + linked list design with a flat preallocated slice removes the map lookup, the per-put slice reallocation, and all list pointer bookkeeping.

**Evict path.** The `_evict` cases cycle through N distinct queries with N > cache size. This is the worst case for LRU under uniform round-robin access:

| | hit rate | why |
|---|---|---|
| master (reject-on-full) | **50%** | First M queries fill the cache and stay forever; every other query misses |
| this PR (LRU) | **0%** | Every cached entry is evicted just before its next use |

Master's 50% hit rate is not the result of a smart policy — it comes from the "freeze the cache once full" behavior accidentally suiting a uniform cyclic pattern. On realistic workloads (some hot queries, some cold, not all arriving at startup) the old policy leaves hot queries permanently uncached, which is exactly the problem rittneje raised. The +40-48% here reflects LRU correctly evicting old entries; it is not a regression in the fix.

Users whose real working set is larger than `_stmt_cache_size` should increase the cache size or disable the cache (`_stmt_cache_size=0`, the default).

## Impact on ad-hoc `db.QueryRow`

Additional numbers from [lirlia/go-sqlite-performance](https://github.com/lirlia/go-sqlite-performance) — `SELECT id, name, hp, attack FROM monster WHERE id = ?` against a 1000-row table, linux/amd64, AMD Ryzen 7 7735HS, single connection, 5 runs. Compares repeated `db.QueryRow(query, args)` with and without `_stmt_cache_size=32`:

| Parallelism | Fair (no cache) | FairCached (cache=32) | Δ |
|---|---:|---:|---:|
| Seq  | 10.80 µs | **7.96 µs** | **-26%** |
| P1   | 43.86 µs | **26.81 µs** | **-39%** |
| P10  | 43.60 µs | **27.43 µs** | **-37%** |
| P100 | 45.44 µs | **28.15 µs** | **-38%** |

On this realistic hot-path workload the cache (introduced in #1387 and correctly LRU-managed in this PR) cuts per-query cost by roughly 37-39% under parallelism and 26% serially. The `BenchmarkStmtCache` microbenchmark above isolates the cache data-structure change; this table shows what it means end-to-end for a user calling `db.QueryRow` in a loop.