### PR TITLE
Don't panic when querying with only comments

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2239,6 +2239,9 @@ func stmtArgs(args []driver.NamedValue, start, na int) []driver.NamedValue {
 }
 
 func (s *SQLiteStmt) bind(args []driver.NamedValue) error {
+	if s.s == nil {
+		return nil
+	}
 	rv := C._sqlite3_reset_clear(s.s)
 	if rv != C.SQLITE_ROW && rv != C.SQLITE_OK && rv != C.SQLITE_DONE {
 		return s.c.lastError()

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -2063,6 +2063,16 @@ func TestNamedParamClearBindings(t *testing.T) {
 	if z.Valid {
 		t.Errorf("Expected z to be NULL, got %d", z.Int64)
 	}
+
+	// Ensure empty statements don't cause panics.
+	_, err = db.Exec("---- comment")
+	if err != nil {
+		t.Fatal("Failed to exec comment only:", err)
+	}
+	_, err = db.Query("---- comment")
+	if err != nil {
+		t.Fatal("Failed to query comment only:", err)
+	}
 }
 
 var customFunctionOnce sync.Once


### PR DESCRIPTION
Fix for https://github.com/mattn/go-sqlite3/issues/1390

Only affects the query path, because the exec path is protected by this: https://github.com/mattn/go-sqlite3/blob/v1.14.42/sqlite3.go#L160