### PR TITLE
fix: Exec returns wrong arg count in "not enough args" error

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -962,7 +962,7 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []driver.Named
 			na := s.NumInput()
 			if len(args)-start < na {
 				s.Close()
-				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args))
+				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args)-start)
 			}
 			stmtArgs := stmtArgs(args, start, na)
 			res, err = s.(*SQLiteStmt).exec(ctx, stmtArgs)

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -2065,6 +2065,36 @@ func TestNamedParamClearBindings(t *testing.T) {
 	}
 }
 
+func TestNotEnoughArgsErrorMessage(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	const want = "not enough args to execute query: want 1 got 0"
+
+	t.Run("exec", func(t *testing.T) {
+		_, err := db.Exec("SELECT ?; SELECT ?", "hello")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != want {
+			t.Errorf("got %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("query", func(t *testing.T) {
+		_, err := db.Query("SELECT ?; SELECT ?", "hello")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != want {
+			t.Errorf("got %q, want %q", err.Error(), want)
+		}
+	})
+}
+
 // https://github.com/mattn/go-sqlite3/issues/1390
 // sqlite3_prepare_v2 returns SQLITE_OK with a NULL statement handle when the
 // input contains no SQL (only whitespace or comments). Querying such input


### PR DESCRIPTION
Aligns the `Exec` "not enough args" message with `Query`'s. Adds a regression test covering both paths.

Fixes #1395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an error message for multi-statement queries so it reports the number of arguments remaining for the current statement.
  * Improved accuracy for both execution and query operations when too few arguments are provided.

* **Tests**
  * Added coverage to verify the corrected error message in relevant query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->