### PR TITLE
add generic _pragma URI parameter support

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1206,6 +1206,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	writableSchema := -1
 	vfsName := ""
 	var cacheSize *int64
+	var pragmas []string
 	stmtCacheSize := 0
 
 	pos := strings.IndexRune(dsn, '?')
@@ -1294,6 +1295,9 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 				return nil, fmt.Errorf("Invalid _auto_vacuum: %v, expecting value of '0 NONE 1 FULL 2 INCREMENTAL'", val)
 			}
 		}
+
+		// _pragma (generic, repeatable — executed in order on every connection)
+		pragmas = params["_pragma"]
 
 		// Busy Timeout (_busy_timeout)
 		//
@@ -1875,6 +1879,14 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	// Cache Size
 	if cacheSize != nil {
 		if err := exec(fmt.Sprintf("PRAGMA cache_size = %d;", *cacheSize)); err != nil {
+			C.sqlite3_close_v2(db)
+			return nil, err
+		}
+	}
+
+	// Generic _pragma parameters — run last so they override specific defaults
+	for _, p := range pragmas {
+		if err := exec(fmt.Sprintf("PRAGMA %s;", p)); err != nil {
 			C.sqlite3_close_v2(db)
 			return nil, err
 		}

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -2131,6 +2131,87 @@ func BenchmarkCustomFunctions(b *testing.B) {
 	}
 }
 
+func TestGenericPragma(t *testing.T) {
+	// Single _pragma applied correctly
+	t.Run("single", func(t *testing.T) {
+		tempFilename := TempFilename(t)
+		defer os.Remove(tempFilename)
+		db, err := sql.Open("sqlite3", tempFilename+"?_pragma=synchronous(NORMAL)")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		var mode int
+		if err := db.QueryRow("PRAGMA synchronous").Scan(&mode); err != nil {
+			t.Fatal(err)
+		}
+		if mode != 1 { // 1 = NORMAL
+			t.Errorf("expected synchronous=1 (NORMAL), got %d", mode)
+		}
+	})
+
+	// Multiple _pragma values applied in order
+	t.Run("multiple", func(t *testing.T) {
+		tempFilename := TempFilename(t)
+		defer os.Remove(tempFilename)
+		db, err := sql.Open("sqlite3", tempFilename+"?_pragma=synchronous(NORMAL)&_pragma=busy_timeout(1234)")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		var sync, timeout int
+		if err := db.QueryRow("PRAGMA synchronous").Scan(&sync); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.QueryRow("PRAGMA busy_timeout").Scan(&timeout); err != nil {
+			t.Fatal(err)
+		}
+		if sync != 1 {
+			t.Errorf("expected synchronous=1 (NORMAL), got %d", sync)
+		}
+		if timeout != 1234 {
+			t.Errorf("expected busy_timeout=1234, got %d", timeout)
+		}
+	})
+
+	// PRAGMAs are re-applied on every connection the pool opens
+	t.Run("pool_reapply", func(t *testing.T) {
+		tempFilename := TempFilename(t)
+		defer os.Remove(tempFilename)
+		db, err := sql.Open("sqlite3", tempFilename+"?_pragma=synchronous(NORMAL)")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		// Force the pool to open multiple distinct connections
+		db.SetMaxOpenConns(4)
+
+		const workers = 4
+		errc := make(chan error, workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				var mode int
+				if err := db.QueryRow("PRAGMA synchronous").Scan(&mode); err != nil {
+					errc <- err
+					return
+				}
+				if mode != 1 {
+					errc <- fmt.Errorf("connection got synchronous=%d, want 1 (NORMAL)", mode)
+					return
+				}
+				errc <- nil
+			}()
+		}
+		for i := 0; i < workers; i++ {
+			if err := <-errc; err != nil {
+				t.Error(err)
+			}
+		}
+	})
+}
+
 func TestSuite(t *testing.T) {
 	initializeTestDB(t)
 	defer freeTestDB()


### PR DESCRIPTION
Implements the _pragma DSN parameter (repeatable, executed in declaration order on every connection) to fix connection-pool PRAGMA persistence. Matches the interface already supported by modernc and ncruces drivers.