### PR TITLE
Fix wrong arg count in Exec's "not enough args" error

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -962,7 +962,7 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []driver.Named
 			na := s.NumInput()
 			if len(args)-start < na {
 				s.Close()
-				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args))
+				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args)-start)
 			}
 			stmtArgs := stmtArgs(args, start, na)
 			res, err = s.(*SQLiteStmt).exec(ctx, stmtArgs)

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1090,6 +1090,38 @@ func TestExecer(t *testing.T) {
 	}
 }
 
+func TestExecNotEnoughArgsErrorMessage(t *testing.T) {
+	tempFilename := TempFilename(t)
+	defer os.Remove(tempFilename)
+	db, err := sql.Open("sqlite3", tempFilename)
+	if err != nil {
+		t.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	// Second statement is missing its arg. The "got" count should reflect
+	// the args remaining after the first statement consumed one, not the
+	// total number of args originally passed in.
+	_, err = db.Exec("SELECT ?; SELECT ?", "hello")
+	if err == nil {
+		t.Fatal("expected error for missing arg")
+	}
+	want := "not enough args to execute query: want 1 got 0"
+	if err.Error() != want {
+		t.Errorf("Exec error message:\n got: %q\nwant: %q", err.Error(), want)
+	}
+
+	// Query already reports the right number; check it stays that way so
+	// the two paths don't drift again.
+	_, err = db.Query("SELECT ?; SELECT ?", "hello")
+	if err == nil {
+		t.Fatal("expected error for missing arg")
+	}
+	if err.Error() != want {
+		t.Errorf("Query error message:\n got: %q\nwant: %q", err.Error(), want)
+	}
+}
+
 func TestQueryer(t *testing.T) {
 	tempFilename := TempFilename(t)
 	defer os.Remove(tempFilename)


### PR DESCRIPTION
Closes #1395

`Exec` and `Query` share the same multi-statement loop and trip the same `len(args)-start < na` check, but the error messages disagree on the second number. With one arg passed to `SELECT ?; SELECT ?`:

```
exec  -> not enough args to execute query: want 1 got 1
query -> not enough args to execute query: want 1 got 0
```

The Query path was already right (args remaining after the first statement consumed one), Exec was printing the total args originally passed in. This just brings Exec in line.

Added a regression test that asserts both paths produce the same message.