### PR TITLE
avoid out of bounds write in unlock_notify_wait on 64 bit platforms

### DIFF
--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -21,6 +21,7 @@ package sqlite3
 extern void unlock_notify_callback(void *arg, int argc);
 */
 import "C"
+
 import (
 	"fmt"
 	"math"
@@ -82,7 +83,7 @@ func unlock_notify_wait(db *C.sqlite3) C.int {
 	h := unt.add(c)
 	defer unt.remove(h)
 
-	pargv := C.malloc(C.sizeof_uint)
+	pargv := C.malloc(C.size_t(unsafe.Sizeof(uint(0))))
 	defer C.free(pargv)
 
 	argv := (*[1]uint)(pargv)


### PR DESCRIPTION
While `C.sizeof_unit` is 4, we convert to a Go uint and write it to the pointer. The Go uint is eight bytes on 64 bit platforms. Allocate the size we intend to write.