### PR TITLE
modernise reflect.SliceHeader to unsafe.Slice

### DIFF
--- a/sqlite3_context.go
+++ b/sqlite3_context.go
@@ -28,7 +28,6 @@ import "C"
 
 import (
 	"math"
-	"reflect"
 	"unsafe"
 )
 
@@ -91,9 +90,11 @@ func (c *SQLiteContext) ResultNull() {
 // ResultText sets the result of an SQL function.
 // See: sqlite3_result_text, http://sqlite.org/c3ref/result_blob.html
 func (c *SQLiteContext) ResultText(s string) {
-	h := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	cs, l := (*C.char)(unsafe.Pointer(h.Data)), C.int(h.Len)
-	C.my_result_text((*C.sqlite3_context)(c), cs, l)
+	if len(s) == 0 {
+		C.my_result_text((*C.sqlite3_context)(c), (*C.char)(unsafe.Pointer(&placeHolder[0])), 0)
+		return
+	}
+	C.my_result_text((*C.sqlite3_context)(c), (*C.char)(unsafe.Pointer(unsafe.StringData(s))), C.int(len(s)))
 }
 
 // ResultZeroblob sets the result of an SQL function.

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -270,7 +270,6 @@ import "C"
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"unsafe"
 )
 
@@ -329,11 +328,7 @@ type InfoOrderBy struct {
 }
 
 func constraints(info *C.sqlite3_index_info) []InfoConstraint {
-	slice := *(*[]C.struct_sqlite3_index_constraint)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(info.aConstraint)),
-		Len:  int(info.nConstraint),
-		Cap:  int(info.nConstraint),
-	}))
+	slice := unsafe.Slice(info.aConstraint, int(info.nConstraint))
 
 	cst := make([]InfoConstraint, 0, len(slice))
 	for _, c := range slice {
@@ -351,11 +346,7 @@ func constraints(info *C.sqlite3_index_info) []InfoConstraint {
 }
 
 func orderBys(info *C.sqlite3_index_info) []InfoOrderBy {
-	slice := *(*[]C.struct_sqlite3_index_orderby)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(info.aOrderBy)),
-		Len:  int(info.nOrderBy),
-		Cap:  int(info.nOrderBy),
-	}))
+	slice := unsafe.Slice(info.aOrderBy, int(info.nOrderBy))
 
 	ob := make([]InfoOrderBy, 0, len(slice))
 	for _, c := range slice {
@@ -400,10 +391,7 @@ func goMInit(db, pClientData unsafe.Pointer, argc C.int, argv **C.char, pzErr **
 		return 0
 	}
 	args := make([]string, argc)
-	var A []*C.char
-	slice := reflect.SliceHeader{Data: uintptr(unsafe.Pointer(argv)), Len: int(argc), Cap: int(argc)}
-	a := reflect.NewAt(reflect.TypeOf(A), unsafe.Pointer(&slice)).Elem().Interface()
-	for i, s := range a.([]*C.char) {
+	for i, s := range unsafe.Slice(argv, int(argc)) {
 		args[i] = C.GoString(s)
 	}
 	var vTab VTab
@@ -466,11 +454,7 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 
 	// Get a pointer to constraint_usage struct so we can update in place.
 
-	slice := *(*[]C.struct_sqlite3_index_constraint_usage)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(info.aConstraintUsage)),
-		Len:  int(info.nConstraint),
-		Cap:  int(info.nConstraint),
-	}))
+	slice := unsafe.Slice(info.aConstraintUsage, int(info.nConstraint))
 	index := 1
 	for i := range slice {
 		if res.Used[i] {
@@ -488,11 +472,7 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 	}
 	info.needToFreeIdxStr = C.int(1)
 
-	idxStr := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(info.idxStr)),
-		Len:  len(res.IdxStr) + 1,
-		Cap:  len(res.IdxStr) + 1,
-	}))
+	idxStr := unsafe.Slice((*byte)(unsafe.Pointer(info.idxStr)), len(res.IdxStr)+1)
 	copy(idxStr, res.IdxStr)
 	idxStr[len(idxStr)-1] = 0 // null-terminated string
 


### PR DESCRIPTION
Avoid the unsafe use of reflect.StringHeader, using the same pattern already in place in `bindText`, and modernise deprecated reflect.SliceHeader usage to unsafe.Slice.