### PR TITLE
fix: correct inconsistent error message in Exec vs Query (#1395)

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -962,7 +962,7 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []driver.Named
 			na := s.NumInput()
 			if len(args)-start < na {
 				s.Close()
-				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args))
+				return nil, fmt.Errorf("not enough args to execute query: want %d got %d", na, len(args)-start)
 			}
 			stmtArgs := stmtArgs(args, start, na)
 			res, err = s.(*SQLiteStmt).exec(ctx, stmtArgs)


### PR DESCRIPTION
## Summary
- Fixed inconsistent error message reporting in Exec and Query methods
- Both methods validate argument count but reported different values
- Now both report remaining args count after start offset

## Root Cause
Query reported len(args)-start correctly, but Exec reported full len(args)

## Changes
- sqlite3.go line 965: Changed to report len(args)-start instead of len(args)
- Aligns error messages between Exec and Query validation

## Test Plan
- [x] Error messages now consistent between methods
- [x] Reports correct argument count in errors
- [x] All argument validation tests pass