### PR TITLE
guard oversized string length in ResultText

### DIFF
--- a/sqlite3_context.go
+++ b/sqlite3_context.go
@@ -90,6 +90,10 @@ func (c *SQLiteContext) ResultNull() {
 // ResultText sets the result of an SQL function.
 // See: sqlite3_result_text, http://sqlite.org/c3ref/result_blob.html
 func (c *SQLiteContext) ResultText(s string) {
+	if i64 && len(s) > math.MaxInt32 {
+		C.sqlite3_result_error_toobig((*C.sqlite3_context)(c))
+		return
+	}
 	if len(s) == 0 {
 		C.my_result_text((*C.sqlite3_context)(c), (*C.char)(unsafe.Pointer(&placeHolder[0])), 0)
 		return


### PR DESCRIPTION
ResultText passes C.int(len(s)) straight through, but ResultBlob already rejects len > math.MaxInt32 on 64-bit. A custom function returning a string over 2 GiB wraps to a negative length, and SQLite then derives the byte count with strlen over the Go string buffer, reading past it. Mirror the existing ResultBlob check so the oversize case returns SQLITE_TOOBIG.