### PR TITLE
bind via sqlite3_bind_text64/blob64 to avoid 32-bit length truncation

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -69,13 +69,13 @@ _sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zV
 }
 
 static int
-_sqlite3_bind_text(sqlite3_stmt *stmt, int n, char *p, int np) {
-  return sqlite3_bind_text(stmt, n, p, np, SQLITE_TRANSIENT);
+_sqlite3_bind_text(sqlite3_stmt *stmt, int n, char *p, sqlite3_uint64 np) {
+  return sqlite3_bind_text64(stmt, n, p, np, SQLITE_TRANSIENT, SQLITE_UTF8);
 }
 
 static int
-_sqlite3_bind_blob(sqlite3_stmt *stmt, int n, void *p, int np) {
-  return sqlite3_bind_blob(stmt, n, p, np, SQLITE_TRANSIENT);
+_sqlite3_bind_blob(sqlite3_stmt *stmt, int n, void *p, sqlite3_uint64 np) {
+  return sqlite3_bind_blob64(stmt, n, p, np, SQLITE_TRANSIENT);
 }
 
 typedef struct {
@@ -2180,9 +2180,9 @@ var placeHolder = []byte{0}
 
 func bindText(s *C.sqlite3_stmt, n C.int, v string) C.int {
 	if len(v) == 0 {
-		return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.int(0))
+		return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.sqlite3_uint64(0))
 	}
-	return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(unsafe.StringData(v))), C.int(len(v)))
+	return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(unsafe.StringData(v))), C.sqlite3_uint64(len(v)))
 }
 
 func bindValue(s *C.sqlite3_stmt, n C.int, value driver.Value) C.int {
@@ -2208,14 +2208,14 @@ func bindValue(s *C.sqlite3_stmt, n C.int, value driver.Value) C.int {
 		if ln == 0 {
 			v = placeHolder
 		}
-		return C._sqlite3_bind_blob(s, n, unsafe.Pointer(&v[0]), C.int(ln))
+		return C._sqlite3_bind_blob(s, n, unsafe.Pointer(&v[0]), C.sqlite3_uint64(ln))
 	case time.Time:
 		var buf [64]byte
 		b := v.AppendFormat(buf[:0], SQLiteTimestampFormats[0])
 		if len(b) == 0 {
-			return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.int(0))
+			return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&placeHolder[0])), C.sqlite3_uint64(0))
 		}
-		return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)))
+		return C._sqlite3_bind_text(s, n, (*C.char)(unsafe.Pointer(&b[0])), C.sqlite3_uint64(len(b)))
 	default:
 		return C.SQLITE_MISUSE
 	}


### PR DESCRIPTION
reading the bind path I noticed bindText and the blob case in bindValue narrow len through C.int before calling sqlite3_bind_text/blob. on 64-bit a parameter of 2 GiB or more wraps to a negative int32, and sqlite then derives the length via strlen over the go buffer which has no guaranteed nul terminator, so it reads past the end. a 4 GiB value instead truncates to a small positive count and binds the wrong bytes. switching the wrappers to the 64-bit variants keeps the full length so sqlite enforces SQLITE_LIMIT_LENGTH and returns SQLITE_TOOBIG. this mirrors the oversize guard already in ResultBlob/ResultText.