### PR TITLE
guard oversized blob length in callbackRetBlob

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -336,6 +336,10 @@ func callbackRetBlob(ctx *C.sqlite3_context, v reflect.Value) error {
 		C.sqlite3_result_null(ctx)
 	} else {
 		bs := i.([]byte)
+		if i64 && len(bs) > math.MaxInt32 {
+			C.sqlite3_result_error_toobig(ctx)
+			return nil
+		}
 		C._sqlite3_result_blob(ctx, unsafe.Pointer(&bs[0]), C.int(len(bs)))
 	}
 	return nil


### PR DESCRIPTION
callbackRetBlob forwards a custom function's []byte return through C.int(len(bs)) to sqlite3_result_blob, but the sqlite3 C API takes the byte count as a signed int. On 64-bit a return value over 2 GiB narrows to a negative length, and since the docs say a negative length is only defined for text, sqlite3VdbeMemSetStr runs the blob terminator scan off the end of the Go buffer, which has no NUL terminator (OOB read). I noticed it while reading the result paths after the earlier bind/result length fixes. Same guard as ResultBlob/ResultText: reject with sqlite3_result_error_toobig when it would not fit.