### PR TITLE
preserve embedded NUL bytes in custom function text values

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -208,8 +208,8 @@ func callbackArgString(v *C.sqlite3_value) (reflect.Value, error) {
 		p := (*C.char)(C.sqlite3_value_blob(v))
 		return reflect.ValueOf(C.GoStringN(p, l)), nil
 	case C.SQLITE_TEXT:
-		l := C.sqlite3_value_bytes(v)
 		c := (*C.char)(unsafe.Pointer(C.sqlite3_value_text(v)))
+		l := C.sqlite3_value_bytes(v)
 		return reflect.ValueOf(C.GoStringN(c, l)), nil
 	default:
 		return reflect.Value{}, fmt.Errorf("argument must be BLOB or TEXT")

--- a/callback.go
+++ b/callback.go
@@ -18,7 +18,7 @@ package sqlite3
 #endif
 #include <stdlib.h>
 
-void _sqlite3_result_text(sqlite3_context* ctx, const char* s);
+void _sqlite3_result_text(sqlite3_context* ctx, const char* s, int n);
 void _sqlite3_result_blob(sqlite3_context* ctx, const void* b, int l);
 */
 import "C"
@@ -208,8 +208,9 @@ func callbackArgString(v *C.sqlite3_value) (reflect.Value, error) {
 		p := (*C.char)(C.sqlite3_value_blob(v))
 		return reflect.ValueOf(C.GoStringN(p, l)), nil
 	case C.SQLITE_TEXT:
+		l := C.sqlite3_value_bytes(v)
 		c := (*C.char)(unsafe.Pointer(C.sqlite3_value_text(v)))
-		return reflect.ValueOf(C.GoString(c)), nil
+		return reflect.ValueOf(C.GoStringN(c, l)), nil
 	default:
 		return reflect.Value{}, fmt.Errorf("argument must be BLOB or TEXT")
 	}
@@ -349,8 +350,13 @@ func callbackRetText(ctx *C.sqlite3_context, v reflect.Value) error {
 	if v.Type().Kind() != reflect.String {
 		return fmt.Errorf("cannot convert %s to TEXT", v.Type())
 	}
-	cstr := C.CString(v.Interface().(string))
-	C._sqlite3_result_text(ctx, cstr)
+	s := v.Interface().(string)
+	if i64 && len(s) > math.MaxInt32 {
+		C.sqlite3_result_error_toobig(ctx)
+		return nil
+	}
+	cstr := C.CString(s)
+	C._sqlite3_result_text(ctx, cstr, C.int(len(s)))
 	return nil
 }
 

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -220,8 +220,8 @@ _sqlite3_prepare_v2_internal(sqlite3 *db, const char *zSql, int nBytes, sqlite3_
 }
 #endif
 
-void _sqlite3_result_text(sqlite3_context* ctx, const char* s) {
-  sqlite3_result_text(ctx, s, -1, &free);
+void _sqlite3_result_text(sqlite3_context* ctx, const char* s, int n) {
+  sqlite3_result_text(ctx, s, n, &free);
 }
 
 void _sqlite3_result_blob(sqlite3_context* ctx, const void* b, int l) {

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1439,6 +1439,42 @@ func TestFunctionRegistration(t *testing.T) {
 	}
 }
 
+func TestFunctionArgStringContainingZero(t *testing.T) {
+	sql.Register("sqlite3_FunctionArgZero", &SQLiteDriver{
+		ConnectHook: func(conn *SQLiteConn) error {
+			// arglen reports how many bytes of the text argument reached the
+			// Go side; echo returns the string result verbatim.
+			if err := conn.RegisterFunc("arglen", func(s string) int64 { return int64(len(s)) }, true); err != nil {
+				return err
+			}
+			return conn.RegisterFunc("echo", func(s string) string { return s }, true)
+		},
+	})
+	db, err := sql.Open("sqlite3_FunctionArgZero", ":memory:")
+	if err != nil {
+		t.Fatal("Failed to open database:", err)
+	}
+	defer db.Close()
+
+	const text = "foo\x00bar"
+
+	var n int64
+	if err := db.QueryRow("SELECT arglen(?)", text).Scan(&n); err != nil {
+		t.Fatal("Failed to call db.QueryRow:", err)
+	}
+	if n != int64(len(text)) {
+		t.Errorf("text argument truncated at embedded NUL: got len %d, want %d", n, len(text))
+	}
+
+	var got string
+	if err := db.QueryRow("SELECT echo(?)", text).Scan(&got); err != nil {
+		t.Fatal("Failed to call db.QueryRow:", err)
+	}
+	if got != text {
+		t.Errorf("text result truncated at embedded NUL: got %q (len %d), want %q (len %d)", got, len(got), text, len(text))
+	}
+}
+
 type sumAggregator int64
 
 func (s *sumAggregator) Step(x int64) {


### PR DESCRIPTION
callbackArgString hands a TEXT argument to a custom function by converting it with C.GoString, which stops at the first NUL byte, so a function declared with a string parameter silently loses everything after an embedded NUL in the value it was given; callbackRetText has the mirror problem and returns its string through sqlite3_result_text with a -1 length, so a returned string is cut off at its first NUL on the way back into the database. A function that filters or validates its input then only sees the bytes before the NUL, which can let the rest slip through unchecked. I read the real byte count with sqlite3_value_bytes on the way in and pass the explicit length to sqlite3_result_text on the way out, with the same oversize guard the blob path already carries since we now hand it a real length.