### PR TITLE
Follow documented call order for sqlite3_value_blob in callbackArgString

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -204,8 +204,8 @@ func callbackArgBytes(v *C.sqlite3_value) (reflect.Value, error) {
 func callbackArgString(v *C.sqlite3_value) (reflect.Value, error) {
 	switch C.sqlite3_value_type(v) {
 	case C.SQLITE_BLOB:
-		l := C.sqlite3_value_bytes(v)
 		p := (*C.char)(C.sqlite3_value_blob(v))
+		l := C.sqlite3_value_bytes(v)
 		return reflect.ValueOf(C.GoStringN(p, l)), nil
 	case C.SQLITE_TEXT:
 		c := (*C.char)(unsafe.Pointer(C.sqlite3_value_text(v)))


### PR DESCRIPTION
The BLOB argument case in callbackArgString called sqlite3_value_bytes before sqlite3_value_blob. SQLite's documented safe order is to call sqlite3_value_blob() first, then sqlite3_value_bytes() (https://www.sqlite.org/c3ref/value_blob.html). This swaps the two so the BLOB case matches the documented order, consistent with the TEXT case fixed in #1406. No behavior change on the UTF-8 path; harmless cleanup.