### PR TITLE
free leaked schema string in GetFilename

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2069,7 +2069,9 @@ func (c *SQLiteConn) GetFilename(schemaName string) string {
 	if schemaName == "" {
 		schemaName = "main"
 	}
-	return C.GoString(C.sqlite3_db_filename(c.db, C.CString(schemaName)))
+	cSchema := C.CString(schemaName)
+	defer C.free(unsafe.Pointer(cSchema))
+	return C.GoString(C.sqlite3_db_filename(c.db, cSchema))
 }
 
 // GetLimit returns the current value of a run-time limit.


### PR DESCRIPTION
GetFilename hands the result of C.CString straight to sqlite3_db_filename, which only borrows the pointer, so the allocation is never released and a little C heap is leaked on every call. It is the only place in the package that builds a C string for an sqlite3 call without a matching free, the siblings all defer it. Stored the pointer and freed it the same way so the schema name no longer leaks.