### PR TITLE
call value_blob/value_text before value_bytes in remaining readers

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -189,12 +189,12 @@ func callbackArgFloat64(v *C.sqlite3_value) (reflect.Value, error) {
 func callbackArgBytes(v *C.sqlite3_value) (reflect.Value, error) {
 	switch C.sqlite3_value_type(v) {
 	case C.SQLITE_BLOB:
-		l := C.sqlite3_value_bytes(v)
 		p := C.sqlite3_value_blob(v)
+		l := C.sqlite3_value_bytes(v)
 		return reflect.ValueOf(C.GoBytes(p, l)), nil
 	case C.SQLITE_TEXT:
-		l := C.sqlite3_value_bytes(v)
 		c := unsafe.Pointer(C.sqlite3_value_text(v))
+		l := C.sqlite3_value_bytes(v)
 		return reflect.ValueOf(C.GoBytes(c, l)), nil
 	default:
 		return reflect.Value{}, fmt.Errorf("argument must be BLOB or TEXT")

--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -74,12 +74,12 @@ func (d *SQLitePreUpdateData) row(dest []any, new bool) error {
 		case C.SQLITE_FLOAT:
 			src = float64(C.sqlite3_value_double(val))
 		case C.SQLITE_BLOB:
-			len := C.sqlite3_value_bytes(val)
 			blobptr := C.sqlite3_value_blob(val)
+			len := C.sqlite3_value_bytes(val)
 			src = C.GoBytes(blobptr, len)
 		case C.SQLITE_TEXT:
-			len := C.sqlite3_value_bytes(val)
 			cstrptr := unsafe.Pointer(C.sqlite3_value_text(val))
+			len := C.sqlite3_value_bytes(val)
 			src = C.GoBytes(cstrptr, len)
 		case C.SQLITE_NULL:
 			src = nil


### PR DESCRIPTION
the same call-order issue fixed in callbackArgString (c3e96cd) still affects callbackArgBytes and the preupdate row reader, where sqlite3_value_bytes is invoked before sqlite3_value_blob/sqlite3_value_text. per the documented safe order the count should be read after the pointer, since an internal type or encoding conversion can otherwise leave the length and the buffer describing different representations and the following C.GoBytes over-reads. reordered both blob and text branches in each to fetch the pointer first, matching callbackArgString and the column reader.