### PR TITLE
cache column metadata for prepared and cached statements

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -476,6 +476,12 @@ type SQLiteStmt struct {
 	cls         bool // True if the statement was created by SQLiteConn.Query
 	namedParams map[string][3]int
 	cacheKey    string
+	metadata    *sqliteStmtMetadata
+}
+
+type sqliteStmtMetadata struct {
+	cols     []string
+	decltype []string
 }
 
 // SQLiteResult implements sql.Result.
@@ -2475,6 +2481,36 @@ func (rc *SQLiteRows) Close() error {
 	return nil
 }
 
+func (s *SQLiteStmt) cacheMetadata() bool {
+	return !s.cls || s.cacheKey != ""
+}
+
+func (s *SQLiteStmt) columnNamesLocked(n int) []string {
+	if s.metadata == nil {
+		s.metadata = &sqliteStmtMetadata{}
+	}
+	if len(s.metadata.cols) != n {
+		s.metadata.cols = make([]string, n)
+		for i := range s.metadata.cols {
+			s.metadata.cols[i] = C.GoString(C.sqlite3_column_name(s.s, C.int(i)))
+		}
+	}
+	return s.metadata.cols
+}
+
+func (s *SQLiteStmt) declTypesLocked(n int) []string {
+	if s.metadata == nil {
+		s.metadata = &sqliteStmtMetadata{}
+	}
+	if len(s.metadata.decltype) != n {
+		s.metadata.decltype = make([]string, n)
+		for i := range s.metadata.decltype {
+			s.metadata.decltype[i] = strings.ToLower(C.GoString(C.sqlite3_column_decltype(s.s, C.int(i))))
+		}
+	}
+	return s.metadata.decltype
+}
+
 // Columns return column names.
 func (rc *SQLiteRows) Columns() []string {
 	if rc.s == nil {
@@ -2483,9 +2519,13 @@ func (rc *SQLiteRows) Columns() []string {
 	rc.s.mu.Lock()
 	defer rc.s.mu.Unlock()
 	if rc.s.s != nil && int(rc.nc) != len(rc.cols) {
-		rc.cols = make([]string, rc.nc)
-		for i := range rc.cols {
-			rc.cols[i] = C.GoString(C.sqlite3_column_name(rc.s.s, C.int(i)))
+		if rc.s.cacheMetadata() {
+			rc.cols = rc.s.columnNamesLocked(int(rc.nc))
+		} else {
+			rc.cols = make([]string, rc.nc)
+			for i := range rc.cols {
+				rc.cols[i] = C.GoString(C.sqlite3_column_name(rc.s.s, C.int(i)))
+			}
 		}
 	}
 	return rc.cols
@@ -2493,9 +2533,13 @@ func (rc *SQLiteRows) Columns() []string {
 
 func (rc *SQLiteRows) declTypes() []string {
 	if rc.s.s != nil && rc.decltype == nil {
-		rc.decltype = make([]string, rc.nc)
-		for i := range rc.decltype {
-			rc.decltype[i] = strings.ToLower(C.GoString(C.sqlite3_column_decltype(rc.s.s, C.int(i))))
+		if rc.s.cacheMetadata() {
+			rc.decltype = rc.s.declTypesLocked(int(rc.nc))
+		} else {
+			rc.decltype = make([]string, rc.nc)
+			for i := range rc.decltype {
+				rc.decltype[i] = strings.ToLower(C.GoString(C.sqlite3_column_decltype(rc.s.s, C.int(i))))
+			}
 		}
 	}
 	return rc.decltype


### PR DESCRIPTION
Column names and declared types are invariant for the lifetime of a compiled statement, but `Columns()` / `declTypes()` called `C.sqlite3_column_name` and `C.sqlite3_column_decltype` once per column on every query. On hot `QueryRow` paths that reuse an explicit `db.Prepare(...)` or a `_stmt_cache_size` cached statement (#1387), this is a fixed set of cgo crossings paid on every execution.

This caches the names and decltypes on the `SQLiteStmt` the first time they are materialized (lazily, under the existing statement mutex) and reuses them afterwards. Caching is gated by `cacheMetadata()`: explicit prepared statements always cache, `Query`-created ephemeral statements cache only when they live in the connection statement cache, and one-shot statements keep the previous per-call behavior. No new allocations on the steady-state hit path, no behavior change for non-cached statements.

Read-only point lookup (`SELECT id, name, hp, attack FROM monster WHERE id = ?`, 1000-row DB, `cache=shared&mode=ro&_journal_mode=WAL`, `_stmt_cache_size=32`), linux/amd64 Ryzen 7 7735HS WSL2, `-benchtime=400ms -count=3` median. `C1`/`C8` = `SetMaxOpenConns`; `P10` ≈ 160 goroutines.

Effect of this change (cached statement path):

| Condition | master | this PR | |
|---|---:|---:|---:|
| C1 Seq | 7.9 µs | 6.6 µs | -16% |
| C1 P10 | 23.4 µs | 18.6 µs | -20% |
| C8 P10 | 12.9 µs | 12.3 µs | -5% |

The win is largest at low / single-connection concurrency, where every cgo crossing sits on the critical path, and shrinks as connection parallelism hides the saved crossings.

For context, best config of each driver on the same workload — `mattn` = `_stmt_cache_size=32` + this change + `SetMaxOpenConns(8)`, `modernc` = `modernc.org/sqlite` with unlimited connections (its fastest setting here). `P1`/`P10`/`P100` ≈ 16 / 160 / 1600 goroutines:

| Condition | mattn | modernc | |
|---|---:|---:|---|
| Seq | 6.3 µs | 13.8 µs | mattn 2.2x |
| P1 | 12.1 µs | 12.5 µs | ~tie |
| P10 | 11.5 µs | 17.1 µs | mattn 1.5x |
| P100 | 13.2 µs | ~115 µs | mattn |

With the statement cache, this metadata cache, and a connection pool sized below the cgo thread-pinning ceiling, `mattn` is competitive-to-faster across the board on this workload.
