### PR TITLE
avoid mutating caller's pass slice in salted crypt encoders

### DIFF
--- a/sqlite3_func_crypt.go
+++ b/sqlite3_func_crypt.go
@@ -59,10 +59,10 @@ func CryptEncoderSHA1(pass []byte, hash any) []byte {
 // configured salt.
 func CryptEncoderSSHA1(salt string) func(pass []byte, hash any) []byte {
 	return func(pass []byte, hash any) []byte {
-		s := []byte(salt)
-		p := append(pass, s...)
-		h := sha1.Sum(p)
-		return h[:]
+		h := sha1.New()
+		h.Write(pass)
+		h.Write([]byte(salt))
+		return h.Sum(nil)
 	}
 }
 
@@ -76,10 +76,10 @@ func CryptEncoderSHA256(pass []byte, hash any) []byte {
 // with the configured salt
 func CryptEncoderSSHA256(salt string) func(pass []byte, hash any) []byte {
 	return func(pass []byte, hash any) []byte {
-		s := []byte(salt)
-		p := append(pass, s...)
-		h := sha256.Sum256(p)
-		return h[:]
+		h := sha256.New()
+		h.Write(pass)
+		h.Write([]byte(salt))
+		return h.Sum(nil)
 	}
 }
 
@@ -93,10 +93,10 @@ func CryptEncoderSHA384(pass []byte, hash any) []byte {
 // with the configured salt
 func CryptEncoderSSHA384(salt string) func(pass []byte, hash any) []byte {
 	return func(pass []byte, hash any) []byte {
-		s := []byte(salt)
-		p := append(pass, s...)
-		h := sha512.Sum384(p)
-		return h[:]
+		h := sha512.New384()
+		h.Write(pass)
+		h.Write([]byte(salt))
+		return h.Sum(nil)
 	}
 }
 
@@ -110,10 +110,10 @@ func CryptEncoderSHA512(pass []byte, hash any) []byte {
 // with the configured salt
 func CryptEncoderSSHA512(salt string) func(pass []byte, hash any) []byte {
 	return func(pass []byte, hash any) []byte {
-		s := []byte(salt)
-		p := append(pass, s...)
-		h := sha512.Sum512(p)
-		return h[:]
+		h := sha512.New()
+		h.Write(pass)
+		h.Write([]byte(salt))
+		return h.Sum(nil)
 	}
 }
 

--- a/sqlite3_func_crypt_test.go
+++ b/sqlite3_func_crypt_test.go
@@ -55,3 +55,29 @@ func TestCryptEncoders(t *testing.T) {
 		}
 	}
 }
+
+// TestSaltedCryptEncoderNoAliasing checks that the salted encoders do not write
+// back through the caller's pass slice. A pass slice with spare capacity used to
+// have the salt appended into its backing array, corrupting neighbouring data the
+// caller still held over the same array.
+func TestSaltedCryptEncoderNoAliasing(t *testing.T) {
+	encoders := map[string]func(string) func([]byte, any) []byte{
+		"ssha1":   CryptEncoderSSHA1,
+		"ssha256": CryptEncoderSSHA256,
+		"ssha384": CryptEncoderSSHA384,
+		"ssha512": CryptEncoderSSHA512,
+	}
+
+	for name, mk := range encoders {
+		backing := make([]byte, 10)
+		copy(backing, []byte("adminXXXXX"))
+		pass := backing[:5]
+		neighbour := backing[5:10]
+
+		mk("salt")(pass, nil)
+
+		if string(neighbour) != "XXXXX" {
+			t.Fatalf("%s mutated caller memory beyond pass: neighbour=%q, want %q", name, neighbour, "XXXXX")
+		}
+	}
+}


### PR DESCRIPTION
the salted variants of the crypt encoders build their hash input with append(pass, salt...). because append reuses the backing array when there is spare capacity, the salt bytes get written past the end of the caller's pass slice and overwrite whatever else happens to live in that array. for a slice carved out of a larger buffer that means a neighbouring slice the caller still holds is silently changed, which is the sort of thing that only shows up intermittently and is awkward to track down on a password path. i ran into it while reading the encoders and reproduced it with a pass slice that shares its backing array with a second slice. switching to a streaming hash, writing pass and then the salt, leaves the digest identical while never writing through the caller's memory. i made the same change to the sha1, sha256, sha384 and sha512 salted encoders since they all shared the pattern, and added a regression test that fails on the old code.