### PR TITLE
Implement ColumnCount method in SQLiteStmt

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2448,6 +2448,14 @@ func (s *SQLiteStmt) Readonly() bool {
 	return C.sqlite3_stmt_readonly(s.s) == 1
 }
 
+// ColumnCount returns the number of columns in the result set returned by
+// the prepared statement, or 0 if it returns no data (e.g. plain INSERT).
+//
+// See: https://sqlite.org/c3ref/column_count.html
+func (s *SQLiteStmt) ColumnCount() int {
+	return int(C.sqlite3_column_count(s.s))
+}
+
 // Close the rows.
 func (rc *SQLiteRows) Close() error {
 	rc.closemu.Lock()

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2470,6 +2470,15 @@ func (s *SQLiteStmt) ColumnCount() int {
 	return int(C.sqlite3_column_count(s.s))
 }
 
+// Tail returns the unprepared remainder of the SQL string this statement was
+// prepared from — everything after the first complete statement, trimmed of
+// whitespace. It is empty when the string held a single statement.
+//
+// See: https://sqlite.org/c3ref/prepare.html (pzTail)
+func (s *SQLiteStmt) Tail() string {
+	return s.t
+}
+
 // Close the rows.
 func (rc *SQLiteRows) Close() error {
 	rc.closemu.Lock()

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -1368,6 +1368,51 @@ func TestBindErrorPaths(t *testing.T) {
 	stmt.Close()
 }
 
+func TestColumnCount(t *testing.T) {
+	d := &SQLiteDriver{}
+	conn, err := d.Open(":memory:")
+	if err != nil {
+		t.Fatal("Failed to open database:", err)
+	}
+	defer conn.Close()
+	c := conn.(*SQLiteConn)
+
+	if _, err := c.Exec("CREATE TABLE t (a, b, c)", nil); err != nil {
+		t.Fatal("Failed to create table:", err)
+	}
+
+	columnCount := func(query string) int {
+		stmt, err := c.Prepare(query)
+		if err != nil {
+			t.Fatalf("Failed to prepare %q: %v", query, err)
+		}
+		defer stmt.Close()
+		return stmt.(*SQLiteStmt).ColumnCount()
+	}
+
+	if n := columnCount("SELECT * FROM t"); n != 3 {
+		t.Errorf("ColumnCount for SELECT * on 3-column table = %d; want 3", n)
+	}
+
+	if _, err := c.Exec("ALTER TABLE t ADD COLUMN d", nil); err != nil {
+		t.Fatal("Failed to add column:", err)
+	}
+	if n := columnCount("SELECT * FROM t"); n != 4 {
+		t.Errorf("ColumnCount after adding a column = %d; want 4", n)
+	}
+
+	if _, err := c.Exec("ALTER TABLE t DROP COLUMN d", nil); err != nil {
+		t.Fatal("Failed to drop column:", err)
+	}
+	if n := columnCount("SELECT * FROM t"); n != 3 {
+		t.Errorf("ColumnCount after dropping a column = %d; want 3", n)
+	}
+
+	if n := columnCount("INSERT INTO t VALUES (1, 2, 3)"); n != 0 {
+		t.Errorf("ColumnCount for INSERT = %d; want 0", n)
+	}
+}
+
 func TestFunctionRegistration(t *testing.T) {
 	addi8_16_32 := func(a int8, b int16) int32 { return int32(a) + int32(b) }
 	addi64 := func(a, b int64) int64 { return a + b }


### PR DESCRIPTION
adds a ColumnCount method to SQLiteStmt, following the same idea as the existing Readonly() wrapper

there is nothing new on the C side. The driver already calls sqlite3_column_count inside query() to size the rows struct, so this just exposes a capability that is already there

motivation:

im running arbitrary SQL. before executing a statement, i need to decide whether to call Query or Exec

this pairs nicely with Readonly(), with both methods available. you can inspect what kind of statement you are holding (it writes? return rows?) without actually running anything

---

this seems to be an easy to review pr, there is no new functionality, follows an existing pattern and is just a few lines. maybe im lost, someone can point me in the right direction ?

@mattn 

@otoolep sorry to ping you but it looks like this may be of interest for rqlite also

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public method to report the number of result columns returned by a prepared SQLite statement.
  * Added a public method to retrieve the remaining SQL text after a prepared statement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->