### PR TITLE
Fix race in SQLiteStmt.Close by holding conn lock across cache check

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -445,12 +445,12 @@ type SQLiteDriver struct {
 
 // SQLiteConn implements driver.Conn.
 type SQLiteConn struct {
-	mu             sync.Mutex
-	db             *C.sqlite3
-	loc            *time.Location
-	txlock         string
-	funcs          []*functionInfo
-	aggregators    []*aggInfo
+	mu          sync.Mutex
+	db          *C.sqlite3
+	loc         *time.Location
+	txlock      string
+	funcs       []*functionInfo
+	aggregators []*aggInfo
 	// Prepared-statement cache. The slice is allocated at Open with a
 	// fixed capacity equal to the configured cache size; cap bounds the
 	// cache, len is the live count, and entries are ordered LRU-first
@@ -1970,6 +1970,10 @@ func (c *SQLiteConn) putCachedStmt(s *SQLiteStmt) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	return c.putCachedStmtLocked(s)
+}
+
+func (c *SQLiteConn) putCachedStmtLocked(s *SQLiteStmt) bool {
 	if c.db == nil {
 		return false
 	}
@@ -2164,11 +2168,19 @@ func (s *SQLiteStmt) Close() error {
 		s.c = nil
 		return nil
 	}
-	if !conn.dbConnOpen() {
+	if s.cacheKey != "" {
+		conn.mu.Lock()
+		if conn.db == nil {
+			conn.mu.Unlock()
+			return errors.New("sqlite statement with already closed database connection")
+		}
+		if conn.putCachedStmtLocked(s) {
+			conn.mu.Unlock()
+			return nil
+		}
+		conn.mu.Unlock()
+	} else if !conn.dbConnOpen() {
 		return errors.New("sqlite statement with already closed database connection")
-	}
-	if s.cacheKey != "" && conn.putCachedStmt(s) {
-		return nil
 	}
 	s.s = nil
 	s.c = nil


### PR DESCRIPTION
In `SQLiteStmt.Close`, the `conn.db == nil` check and the insertion into the statement cache happened in separate lock regions, so the connection could be closed in between (a TOCTOU race). This change performs the check and the cache insertion within a single lock region (extracted as `putCachedStmtLocked`).

## Benchmark (before/after)

`go test -bench BenchmarkStmtCache -benchmem -count 6`

```
                                 │  before.txt  │             after.txt              │
                                 │    sec/op    │    sec/op     vs base              │
StmtCache/off-16                   2.306µ ± 13%   2.129µ ±  2%  -7.68% (p=0.002 n=6)
StmtCache/size4_keys1_hit-16       903.7n ± 15%   867.8n ± 20%       ~ (p=0.310 n=6)
StmtCache/size4_keys4_hit-16       902.8n ±  2%   894.8n ± 15%       ~ (p=0.660 n=6)
StmtCache/size4_keys8_evict-16     2.558µ ±  2%   2.677µ ± 20%       ~ (p=0.394 n=6)
StmtCache/size16_keys8_hit-16      936.0n ±  9%   905.9n ± 36%       ~ (p=0.394 n=6)
StmtCache/size16_keys32_evict-16   2.599µ ±  3%   2.593µ ± 15%       ~ (p=0.974 n=6)
geomean                            1.507µ         1.477µ        -1.96%
```

B/op and allocs/op are identical before/after. No performance impact; differences are within noise.
