### PR TITLE
Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+reviews:
+  # Skip the vendored SQLite amalgamation. These files are copied verbatim from
+  # upstream SQLite (see the License section in README.md) and are not code that
+  # this project authors or reviews.
+  path_filters:
+    - "!sqlite3-binding.c"
+    - "!sqlite3-binding.h"
+    - "!sqlite3ext.h"
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds a `.coderabbit.yaml` so CodeRabbit reviews stay focused on this project's own code.

The vendored SQLite amalgamation is excluded from reviews:
- `sqlite3-binding.c` (~9.5 MB generated file)
- `sqlite3-binding.h`
- `sqlite3ext.h`

These are copied verbatim from upstream SQLite (see the License section in README.md), so there is nothing for the reviewer to comment on there, and skipping them avoids noise and wasted processing on a very large generated file.