### PR TITLE
Return error from vtable cursor open instead of ignoring it

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -113,6 +113,9 @@ uintptr_t goVOpen(void *pVTab, char **pzErr);
 
 static int cXOpen(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor) {
 	void *vTabCursor = (void *)goVOpen(((goVTab*)pVTab)->vTab, &(pVTab->zErrMsg));
+	if (!vTabCursor) {
+		return SQLITE_ERROR;
+	}
 	goVTabCursor *pCursor = (goVTabCursor *)sqlite3_malloc(sizeof(goVTabCursor));
 	if (!pCursor) {
 		return SQLITE_NOMEM;


### PR DESCRIPTION
cXOpen ignored the error sentinel from goVOpen and returned SQLITE_OK with a nil cursor handle, so a VTabCursor whose Open() fails caused a panic in later callbacks (xFilter/xEof) instead of returning the SQL error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when initializing virtual table cursors.
  * Prevented operations from continuing when cursor creation fails, avoiding potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->