### PR TITLE
Check sqlite3_malloc64 result in Deserialize

### DIFF
--- a/sqlite3_opt_serialize.go
+++ b/sqlite3_opt_serialize.go
@@ -60,6 +60,9 @@ func (c *SQLiteConn) Deserialize(b []byte, schema string) error {
 	defer C.free(unsafe.Pointer(zSchema))
 
 	tmpBuf := (*C.uchar)(C.sqlite3_malloc64(C.sqlite3_uint64(len(b))))
+	if tmpBuf == nil && len(b) > 0 {
+		return fmt.Errorf("deserialize failed: out of memory")
+	}
 	copy(unsafe.Slice((*byte)(unsafe.Pointer(tmpBuf)), len(b)), b)
 
 	rc := C.sqlite3_deserialize(c.db, zSchema, tmpBuf, C.sqlite3_int64(len(b)),


### PR DESCRIPTION
Deserialize did not check the result of sqlite3_malloc64, so an allocation failure caused a write through a NULL pointer and crashed the process instead of returning an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of low-memory conditions during database deserialization.
  * Returns a clear out-of-memory error instead of proceeding with an invalid buffer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->