### PR TITLE
Check preupdate value fetch result to avoid NULL dereference

### DIFF
--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -59,13 +59,17 @@ func (d *SQLitePreUpdateData) row(dest []any, new bool) error {
 	for i := 0; i < d.Count() && i < len(dest); i++ {
 		var val *C.sqlite3_value
 		var src any
+		var rc C.int
 
 		// Initially I tried making this just a function pointer argument, but
 		// it's absurdly complicated to pass C function pointers.
 		if new {
-			C.sqlite3_preupdate_new(d.Conn.db, C.int(i), &val)
+			rc = C.sqlite3_preupdate_new(d.Conn.db, C.int(i), &val)
 		} else {
-			C.sqlite3_preupdate_old(d.Conn.db, C.int(i), &val)
+			rc = C.sqlite3_preupdate_old(d.Conn.db, C.int(i), &val)
+		}
+		if rc != C.SQLITE_OK {
+			return Error{Code: ErrNo(rc)}
 		}
 
 		switch C.sqlite3_value_type(val) {


### PR DESCRIPTION
The return codes of sqlite3_preupdate_new/old were ignored, so on failure the sqlite3_value pointer stayed NULL and sqlite3_value_type dereferenced it and crashed. Return the error instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving pre-update values from SQLite.
  * Clearer errors are now returned when SQLite cannot provide the requested data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->