### PR TITLE
Fix leak of extension load error message

### DIFF
--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -74,11 +74,11 @@ func (c *SQLiteConn) loadExtension(lib string, entry *string) error {
 	}
 
 	var errMsg *C.char
-	defer C.sqlite3_free(unsafe.Pointer(errMsg))
-
 	rv := C.sqlite3_load_extension(c.db, clib, centry, &errMsg)
 	if rv != C.SQLITE_OK {
-		return errors.New(C.GoString(errMsg))
+		err := errors.New(C.GoString(errMsg))
+		C.sqlite3_free(unsafe.Pointer(errMsg))
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The deferred sqlite3_free evaluated errMsg at defer time, when it was still nil, so the error message allocated by sqlite3_load_extension was never freed and leaked on every failed extension load. Free it after reading the message instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading SQLite extensions, ensuring failure messages are returned correctly and associated resources are released safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->