### PR TITLE
Do not clobber SQLite's default cost estimates in BestIndex

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -482,8 +482,22 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 	if res.AlreadyOrdered {
 		info.orderByConsumed = C.int(1)
 	}
-	info.estimatedCost = C.double(res.EstimatedCost)
-	info.estimatedRows = C.sqlite3_int64(res.EstimatedRows)
+	// SQLite pre-initializes estimatedCost and estimatedRows with sensible
+	// defaults; overwriting them with the Go zero value would make every
+	// candidate plan look free and break query planning, so only pass
+	// values the implementation actually set.
+	if res.EstimatedCost > 0 {
+		info.estimatedCost = C.double(res.EstimatedCost)
+	}
+	if res.EstimatedRows > 0 {
+		var rows int64
+		if res.EstimatedRows >= float64(math.MaxInt64) {
+			rows = math.MaxInt64
+		} else {
+			rows = int64(res.EstimatedRows)
+		}
+		info.estimatedRows = C.sqlite3_int64(rows)
+	}
 
 	return nil
 }

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -493,8 +493,9 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 		var rows int64
 		if res.EstimatedRows >= float64(math.MaxInt64) {
 			rows = math.MaxInt64
-		} else {
-			rows = int64(res.EstimatedRows)
+		} else if rows = int64(res.EstimatedRows); rows < 1 {
+			// A positive fractional estimate must not truncate to 0.
+			rows = 1
 		}
 		info.estimatedRows = C.sqlite3_int64(rows)
 	}


### PR DESCRIPTION
goVBestIndex unconditionally overwrote estimatedCost and estimatedRows with the IndexResult fields, so implementations that leave them unset reported cost 0 for every candidate plan, breaking query planning. Keep SQLite's pre-initialized defaults unless the implementation set a positive value, and clamp the float-to-int64 conversion of EstimatedRows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning by preserving SQLite’s default estimated cost and row counts when custom estimates are not provided.
  * Added safer handling for estimated row counts, including protection against very large values and preventing small fractional estimates from being stored as zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->