### PR TITLE
Translate SQL NULL filter arguments to nil like goVUpdate

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -514,7 +514,14 @@ func goVFilter(pCursor unsafe.Pointer, idxNum C.int, idxName *C.char, argc C.int
 		if err != nil {
 			return mPrintf("%s", err.Error())
 		}
-		vals = append(vals, conv.Interface())
+
+		// work around for SQLITE_NULL
+		x := conv.Interface()
+		if z, ok := x.([]byte); ok && z == nil {
+			x = nil
+		}
+
+		vals = append(vals, x)
 	}
 	err := vtc.vTabCursor.Filter(int(idxNum), C.GoString(idxName), vals)
 	if err != nil {


### PR DESCRIPTION
goVFilter passed SQL NULL constraint values to VTabCursor.Filter as a nil []byte instead of nil, making NULL indistinguishable from a blob at the Go level. Apply the same workaround goVUpdate already uses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SQLite `NULL` values during filtering operations.
  * Prevented `NULL` values from being incorrectly represented as empty byte data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->