### PR TITLE
Identify updated row by argv 0 in goVUpdate

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -608,7 +608,9 @@ func goVUpdate(pVTab unsafe.Pointer, argc C.int, argv **C.sqlite3_value, pRowid 
 			}
 
 		case argc > 1:
-			err = v.Update(vals[1], vals[2:])
+			// Per the xUpdate contract argv[0] identifies the row being
+			// updated while argv[1] is its (possibly changed) new rowid.
+			err = v.Update(vals[0], vals[2:])
 		}
 	}
 

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -609,8 +609,14 @@ func goVUpdate(pVTab unsafe.Pointer, argc C.int, argv **C.sqlite3_value, pRowid 
 
 		case argc > 1:
 			// Per the xUpdate contract argv[0] identifies the row being
-			// updated while argv[1] is its (possibly changed) new rowid.
-			err = v.Update(vals[0], vals[2:])
+			// updated while argv[1] is its new rowid. VTabUpdater has no
+			// way to convey a rowid change, so reject it instead of
+			// silently updating values under the old rowid.
+			if vals[0] != vals[1] {
+				err = fmt.Errorf("virtual %s table %sdoes not support changing the rowid", vt.module.name, tname)
+			} else {
+				err = v.Update(vals[0], vals[2:])
+			}
 		}
 	}
 

--- a/sqlite3_opt_vtable_test.go
+++ b/sqlite3_opt_vtable_test.go
@@ -280,6 +280,19 @@ func TestVUpdate(t *testing.T) {
 		t.Fatalf("expected table vt entry 1 to be [117 f e], instead: %v", vt.data[1])
 	}
 
+	// a rowid-changing update cannot be expressed via VTabUpdater and
+	// must be rejected instead of updating the wrong row
+	_, err = db.Exec(`update vt set rowid = rowid + 10 where f1 = 117`)
+	if err == nil {
+		t.Fatalf("expected error on rowid-changing update, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not support changing the rowid") {
+		t.Fatalf("unexpected error on rowid-changing update: %v", err)
+	}
+	if !reflect.DeepEqual(vt.data[1], []any{int64(117), "f", "e"}) {
+		t.Fatalf("expected table vt entry 1 to be unchanged, instead: %v", vt.data[1])
+	}
+
 	// delete from vt
 	res, err = db.Exec(`delete from vt where f1 = 117`)
 	if err != nil {


### PR DESCRIPTION
Per the xUpdate contract argv[0] is the rowid of the row being updated and argv[1] is its new rowid, but goVUpdate passed argv[1] to VTabUpdater.Update. A statement like UPDATE vt SET rowid = rowid + 1 therefore updated the wrong row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual table `UPDATE` behavior is now consistent with the expected update contract when row identifiers are involved.
  * If an update attempts to change a row’s `rowid`, the operation is now rejected with a clear error, and the existing row data remains unchanged.
  * Added coverage to ensure row identifier change attempts fail and do not corrupt stored values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->