### PR TITLE
Ignore Used for constraints SQLite marked not usable

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -460,7 +460,11 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 	slice := unsafe.Slice(info.aConstraintUsage, int(info.nConstraint))
 	index := 1
 	for i := range slice {
-		if res.Used[i] {
+		// SQLite returns "xBestIndex malfunction" when an argvIndex is
+		// assigned to a constraint it marked as not usable, so ignore
+		// Used for those; they may become usable on a later xBestIndex
+		// invocation for a different plan.
+		if res.Used[i] && csts[i].Usable {
 			slice[i].argvIndex = C.int(index)
 			slice[i].omit = C.uchar(1)
 			index++


### PR DESCRIPTION
Assigning an argvIndex to a constraint whose usable flag is clear makes SQLite fail the query with an opaque "xBestIndex malfunction" error. This happens easily in joins, where xBestIndex is re-invoked with some constraints marked unusable. Skip those constraints when applying IndexResult.Used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query planning reliability by ignoring unavailable constraints when assigning constraint parameters.
  * Prevented potential SQLite “xBestIndex malfunction” errors during query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->