### PR TITLE
Reject nil module and nil BestIndex result

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -451,6 +451,9 @@ func goVBestIndex(pVTab unsafe.Pointer, icp unsafe.Pointer) *C.char {
 	if err != nil {
 		return mPrintf("%s", err.Error())
 	}
+	if res == nil {
+		return mPrintf("%s", "BestIndex returned a nil IndexResult")
+	}
 	if len(res.Used) != len(csts) {
 		return mPrintf("Result.Used != expected value", "")
 	}
@@ -708,5 +711,5 @@ func (c *SQLiteConn) CreateModule(moduleName string, module Module) error {
 		}
 		return nil
 	}
-	return nil
+	return fmt.Errorf("sqlite3: CreateModule requires a non-nil module")
 }


### PR DESCRIPTION
CreateModule with a nil module silently returned success without registering anything, and a BestIndex implementation returning (nil, nil) crashed with a nil dereference inside the cgo callback. Return proper errors for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent errors when virtual table index results are missing.
  * Virtual table modules with invalid definitions now return an error instead of appearing to register successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->