### PR TITLE
Fix off-by-one truncating SQL in fuzz target

### DIFF
--- a/_example/fuzz/fuzz_openexec.go
+++ b/_example/fuzz/fuzz_openexec.go
@@ -22,7 +22,7 @@ func FuzzOpenExec(data []byte) int {
 		return 0
 	}
 	defer db.Close()
-	_, err = db.Exec(string(data[:sep-1]))
+	_, err = db.Exec(string(data[:sep]))
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
The fuzz target executed data[:sep-1] instead of data[:sep], dropping the last byte of every generated SQL statement, so the fuzzer could rarely execute a complete statement it constructed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated fuzz testing to correctly interpret the SQL statement boundary when executing fuzz-generated input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->