### PR TITLE
Use the table name from xCreate args in vtable example

### DIFF
--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/mattn/go-sqlite3"
 )
@@ -26,13 +27,14 @@ func (m *githubModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTa
 	if len(args) < 3 {
 		return nil, fmt.Errorf("githubModule: unexpected arguments: %v", args)
 	}
+	tableName := `"` + strings.ReplaceAll(args[2], `"`, `""`) + `"`
 	err := c.DeclareVTab(fmt.Sprintf(`
 		CREATE TABLE %s (
 			id INT,
 			full_name TEXT,
 			description TEXT,
 			html_url TEXT
-		)`, args[2]))
+		)`, tableName))
 	if err != nil {
 		return nil, err
 	}

--- a/_example/vtable/vtable.go
+++ b/_example/vtable/vtable.go
@@ -20,13 +20,19 @@ type githubModule struct {
 }
 
 func (m *githubModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
+	// args holds the raw xCreate arguments: args[0] is the module name,
+	// args[1] the database name, args[2] the virtual table name, and any
+	// user arguments follow.
+	if len(args) < 3 {
+		return nil, fmt.Errorf("githubModule: unexpected arguments: %v", args)
+	}
 	err := c.DeclareVTab(fmt.Sprintf(`
 		CREATE TABLE %s (
 			id INT,
 			full_name TEXT,
 			description TEXT,
 			html_url TEXT
-		)`, args[0]))
+		)`, args[2]))
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +55,9 @@ func (v *ghRepoTable) Open() (sqlite3.VTabCursor, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching repositories: %s", resp.Status)
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
The github vtable example passed args[0] (the module name) to DeclareVTab where the table name (args[2]) belongs; it only worked because SQLite ignores the name in the declaration. Also check the HTTP status so a rate-limited API response yields a clear error instead of a JSON unmarshal failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent virtual table creation when insufficient arguments are provided.
  * Corrected virtual table naming during SQLite schema creation.
  * Improved error handling for failed GitHub repository requests by reporting non-successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->