### PR TITLE
Close leaked rows in hook example

### DIFF
--- a/_example/hook/hook.go
+++ b/_example/hook/hook.go
@@ -45,10 +45,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	_, err = srcDb.Query("select * from foo")
+	rows, err := srcDb.Query("select * from foo")
 	if err != nil {
 		log.Fatal(err)
 	}
+	rows.Close()
 	destDb, err := sql.Open("sqlite3_with_hook_example", "./bar.db")
 	if err != nil {
 		log.Fatal(err)
@@ -65,14 +66,17 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	_, err = destDb.Query("select * from foo")
+	rows, err = destDb.Query("select * from foo")
 	if err != nil {
 		log.Fatal(err)
 	}
+	rows.Close()
 	_, err = destDb.Exec("insert into foo values(3, 'bar')")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	bk.Finish()
+	if err := bk.Finish(); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Two sql.Rows returned by Query were discarded without Close, keeping their connections checked out of the pool for the life of the process. Also check the Finish error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup completion error handling by reporting failures instead of silently ignoring them.
  * Ensured database query results are properly closed during the backup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->