### PR TITLE
Close prepared statement and fail if limit is not enforced in limit example

### DIFF
--- a/_example/limit/limit.go
+++ b/_example/limit/limit.go
@@ -32,6 +32,7 @@ func bulkInsert(db *sql.DB, query string, args []any) (err error) {
 	if err != nil {
 		return
 	}
+	defer stmt.Close()
 
 	_, err = stmt.Exec(args...)
 	if err != nil {
@@ -89,11 +90,10 @@ func main() {
 
 	query, args = createBulkInsertQuery(num, num)
 	err = bulkInsert(db, query, args)
-	if err != nil {
-		if err != nil {
-			log.Printf("expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: %v", err)
-		}
+	if err == nil {
+		log.Fatal("expected failure since SQLITE_LIMIT_VARIABLE_NUMBER is too small, but insert succeeded")
 	}
+	log.Printf("expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: %v", err)
 
 	bigLimitVariableNumber := 999999
 	sqlite3conn.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, bigLimitVariableNumber)
@@ -104,9 +104,7 @@ func main() {
 	query, args = createBulkInsertQuery(500, num+num)
 	err = bulkInsert(db, query, args)
 	if err != nil {
-		if err != nil {
-			log.Fatal(err)
-		}
+		log.Fatal(err)
 	}
 
 	log.Println("no error if SQLITE_LIMIT_VARIABLE_NUMBER > 999")

--- a/_example/limit/limit.go
+++ b/_example/limit/limit.go
@@ -93,6 +93,9 @@ func main() {
 	if err == nil {
 		log.Fatal("expected failure since SQLITE_LIMIT_VARIABLE_NUMBER is too small, but insert succeeded")
 	}
+	if !strings.Contains(err.Error(), "too many SQL variables") {
+		log.Fatalf("expected too many SQL variables error, got: %v", err)
+	}
 	log.Printf("expect failed since SQLITE_LIMIT_VARIABLE_NUMBER is too small: %v", err)
 
 	bigLimitVariableNumber := 999999


### PR DESCRIPTION
bulkInsert leaked a prepared statement on every call, which also made the pool open extra connections and could run the inserts on a connection without the configured limit. Close the statement, and fail instead of logging when the insert that must exceed SQLITE_LIMIT_VARIABLE_NUMBER unexpectedly succeeds (also removes doubled err checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during bulk inserts by ensuring prepared statements are properly closed.
  * Updated the limit example to fail when an insert unexpectedly succeeds, and to validate the error message when failures are expected.
  * Simplified error handling for the large-limit insert scenario to make behavior clearer and more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->