### PR TITLE
Handle NULL and BLOB values in json example Scan

### DIFF
--- a/_example/json/json.go
+++ b/_example/json/json.go
@@ -16,7 +16,17 @@ type Tag struct {
 }
 
 func (t *Tag) Scan(value interface{}) error {
-	return json.Unmarshal([]byte(value.(string)), t)
+	switch v := value.(type) {
+	case nil:
+		*t = Tag{}
+		return nil
+	case string:
+		return json.Unmarshal([]byte(v), t)
+	case []byte:
+		return json.Unmarshal(v, t)
+	default:
+		return fmt.Errorf("unsupported type %T for Tag", value)
+	}
 }
 
 func (t *Tag) Value() (driver.Value, error) {


### PR DESCRIPTION
Tag.Scan asserted value.(string) directly, panicking on NULL rows and on BLOB (jsonb) columns. Switch over string, []byte and nil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tag data returned from different database drivers.
  * Tags can now be read from strings, byte arrays, or empty values without errors.
  * Unsupported data types now return a clear error instead of causing a panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->