### PR TITLE
Add workflow to create releases on tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, skipping"
+            exit 0
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "${GITHUB_REF_NAME#v}" \
+            --verify-tag \
+            --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Create release
@@ -17,9 +21,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+          set -euo pipefail
+          if output=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" 2>&1); then
             echo "Release $GITHUB_REF_NAME already exists, skipping"
             exit 0
+          elif ! grep -qi "release not found" <<< "$output"; then
+            # A lookup failure other than "not found" (auth, network, API)
+            # must not fall through to the create step.
+            echo "$output" >&2
+            exit 1
           fi
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
Pushing a v* tag now creates the GitHub release automatically with generated notes (What's Changed / New Contributors / Full Changelog, same format as the v1.14.48 notes). Skips tags that already have a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated release workflow that creates a release when version tags (e.g., `v*`) are pushed.
  * Avoids creating duplicate releases by checking whether a release already exists for the tag.
  * Automatically generates release notes and verifies the tag before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->