### PR TITLE
Avoid per-row goroutines for query cancellation

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -445,8 +445,11 @@ type SQLiteDriver struct {
 
 // SQLiteConn implements driver.Conn.
 type SQLiteConn struct {
-	mu          sync.Mutex
-	db          *C.sqlite3
+	mu sync.Mutex
+	db *C.sqlite3
+	// activeRows identifies the cancellable Rows currently calling sqlite3_step.
+	// It is guarded by mu so a stale cancellation cannot interrupt later work.
+	activeRows  *SQLiteRows
 	loc         *time.Location
 	txlock      string
 	funcs       []*functionInfo
@@ -492,14 +495,15 @@ type SQLiteResult struct {
 
 // SQLiteRows implements driver.Rows.
 type SQLiteRows struct {
-	s        *SQLiteStmt
-	nc       int32 // Number of columns
-	cls      bool  // True if we need to close the parent statement in Close
-	cols     []string
-	decltype []string
-	colvals  *C.sqlite3_go_col
-	ctx      context.Context // no better alternative to pass context into Next() method
-	closemu  sync.Mutex
+	s                *SQLiteStmt
+	nc               int32 // Number of columns
+	cls              bool  // True if we need to close the parent statement in Close
+	cols             []string
+	decltype         []string
+	colvals          *C.sqlite3_go_col
+	ctx              context.Context // no better alternative to pass context into Next() method
+	stopCancellation func() bool
+	closemu          sync.Mutex
 }
 
 type functionInfo struct {
@@ -2466,6 +2470,7 @@ func (s *SQLiteStmt) Readonly() bool {
 func (rc *SQLiteRows) Close() error {
 	rc.closemu.Lock()
 	defer rc.closemu.Unlock()
+	rc.stopWatchingCancellation()
 	s := rc.s
 	if s == nil {
 		if rc.colvals != nil {
@@ -2495,6 +2500,40 @@ func (rc *SQLiteRows) Close() error {
 	}
 	s.mu.Unlock()
 	return nil
+}
+
+func (c *SQLiteConn) interruptActiveRows(rows *SQLiteRows) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRows == rows && c.db != nil {
+		C.sqlite3_interrupt(c.db)
+	}
+}
+
+func (rc *SQLiteRows) stopWatchingCancellation() {
+	if rc.stopCancellation == nil {
+		return
+	}
+	// A false return is harmless: a callback already in progress can interrupt
+	// only while rc owns conn.activeRows, which is guarded by conn.mu.
+	rc.stopCancellation()
+	rc.stopCancellation = nil
+}
+
+func (rc *SQLiteRows) startStepping() {
+	conn := rc.s.c
+	conn.mu.Lock()
+	conn.activeRows = rc
+	conn.mu.Unlock()
+}
+
+func (rc *SQLiteRows) finishStepping() {
+	conn := rc.s.c
+	conn.mu.Lock()
+	if conn.activeRows == rc {
+		conn.activeRows = nil
+	}
+	conn.mu.Unlock()
 }
 
 func (s *SQLiteStmt) cacheMetadata() bool {
@@ -2583,33 +2622,34 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
-	if rc.ctx.Done() == nil {
-		return rc.nextSyncLocked(dest)
-	}
-	sema := make(chan struct{})
-	var err error
-	go func() {
-		err = rc.nextSyncLocked(dest)
-		close(sema)
-	}()
-	select {
-	case <-sema:
-		return err
-	case <-rc.ctx.Done():
-		select {
-		case <-sema: // no need to interrupt
-		default:
-			// this is still racy and can be no-op if executed between sqlite3_* calls in nextSyncLocked.
-			C.sqlite3_interrupt(rc.s.c.db)
-			<-sema // ensure goroutine completed
+	if rc.stopCancellation == nil {
+		if rc.ctx.Done() == nil {
+			rv := C._sqlite3_step_internal(rc.s.s)
+			return rc.readStepResultLocked(dest, rv)
 		}
-		return rc.ctx.Err()
+		conn := rc.s.c
+		rc.stopCancellation = context.AfterFunc(rc.ctx, func() {
+			conn.interruptActiveRows(rc)
+		})
 	}
+	if err := rc.ctx.Err(); err != nil {
+		return err
+	}
+	rv := rc.stepCancellableLocked()
+	err := rc.readStepResultLocked(dest, rv)
+	if ctxErr := rc.ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }
 
-// nextSyncLocked moves cursor to next; must be called with locked mutex.
-func (rc *SQLiteRows) nextSyncLocked(dest []driver.Value) error {
-	rv := C._sqlite3_step_internal(rc.s.s)
+func (rc *SQLiteRows) stepCancellableLocked() C.int {
+	rc.startStepping()
+	defer rc.finishStepping()
+	return C._sqlite3_step_internal(rc.s.s)
+}
+
+func (rc *SQLiteRows) readStepResultLocked(dest []driver.Value, rv C.int) error {
 	if rv == C.SQLITE_DONE {
 		return io.EOF
 	}

--- a/sqlite3_context_test.go
+++ b/sqlite3_context_test.go
@@ -1,0 +1,479 @@
+//go:build cgo
+// +build cgo
+
+package sqlite3
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const contextTestTimeout = 5 * time.Second
+const contextTestMaxRows = int64(1 << 60)
+
+const contextTestControlledQuery = `
+	WITH RECURSIVE numbers(value) AS (
+		VALUES(0)
+		UNION ALL
+		SELECT value + 1 FROM numbers
+		WHERE value < ? AND context_cancel_continue()
+	)
+	SELECT sum(value) FROM numbers`
+
+func TestRowsContextCancelDuringStep(t *testing.T) {
+	conn := openContextTestConn(t)
+	started, stopQuery := registerContextTestQuery(t, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rows, err := conn.QueryContext(ctx, contextTestControlledQuery, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- rows.Next(make([]driver.Value, 1))
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		cancel()
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("query did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-nextDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Next error = %v, want context.Canceled", err)
+		}
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("Next did not return after cancellation")
+	}
+}
+
+func TestRowsContextCancelBetweenRows(t *testing.T) {
+	conn := openContextTestConn(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	rows, err := conn.QueryContext(ctx, "SELECT 1 UNION ALL SELECT 2", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	values := make([]driver.Value, 1)
+	if err := rows.Next(values); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+	cancel()
+	if err := rows.Next(values); !errors.Is(err, context.Canceled) {
+		t.Fatalf("second Next error = %v, want context.Canceled", err)
+	}
+}
+
+func TestRowsInterruptIgnoresInactiveRows(t *testing.T) {
+	conn := openContextTestConn(t)
+
+	idleCtx, cancelIdle := context.WithCancel(context.Background())
+	defer cancelIdle()
+	idleRows, err := conn.QueryContext(idleCtx, "SELECT 1 UNION ALL SELECT 2", nil)
+	if err != nil {
+		t.Fatalf("query idle rows: %v", err)
+	}
+	defer idleRows.Close()
+	if err := idleRows.Next(make([]driver.Value, 1)); err != nil {
+		t.Fatalf("read idle rows: %v", err)
+	}
+
+	started, stopQuery := registerContextTestQuery(t, conn)
+	activeCtx, cancelActive := context.WithCancel(context.Background())
+	defer cancelActive()
+	activeRows, err := conn.QueryContext(activeCtx, contextTestControlledQuery, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query active rows: %v", err)
+	}
+	defer activeRows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- activeRows.Next(make([]driver.Value, 1))
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("active query did not start")
+	}
+
+	// Invoke the callback guard directly so the test does not depend on scheduling.
+	conn.interruptActiveRows(idleRows.(*SQLiteRows))
+	if err := stopContextTestQuery(t, stopQuery, nextDone); err != nil {
+		t.Fatalf("active query was interrupted: %v", err)
+	}
+}
+
+func TestRowsLateInterruptDoesNotAffectReusedStatement(t *testing.T) {
+	conn := openContextTestConn(t)
+	started, stopQuery := registerContextTestQuery(t, conn)
+	stmtDriver, err := conn.Prepare(contextTestControlledQuery)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	defer stmtDriver.Close()
+	stmt := stmtDriver.(*SQLiteStmt)
+
+	oldCtx, cancelOld := context.WithCancel(context.Background())
+	defer cancelOld()
+	oldRows, err := stmt.QueryContext(oldCtx, contextTestQueryArgs(0))
+	if err != nil {
+		t.Fatalf("query old rows: %v", err)
+	}
+	if err := oldRows.Next(make([]driver.Value, 1)); err != nil {
+		t.Fatalf("read old rows: %v", err)
+	}
+	if err := oldRows.Close(); err != nil {
+		t.Fatalf("close old rows: %v", err)
+	}
+
+	newCtx, cancelNew := context.WithCancel(context.Background())
+	defer cancelNew()
+	newRows, err := stmt.QueryContext(newCtx, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query new rows: %v", err)
+	}
+	defer newRows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- newRows.Next(make([]driver.Value, 1))
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("replacement query did not start")
+	}
+
+	// Simulate a callback that started before oldRows was closed.
+	conn.interruptActiveRows(oldRows.(*SQLiteRows))
+	if err := stopContextTestQuery(t, stopQuery, nextDone); err != nil {
+		t.Fatalf("replacement query was interrupted: %v", err)
+	}
+}
+
+func TestRowsContextCancelAndClose(t *testing.T) {
+	conn := openContextTestConn(t)
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		rows, err := conn.QueryContext(ctx, "SELECT 1 UNION ALL SELECT 2", nil)
+		if err != nil {
+			t.Fatalf("query cancellable rows: %v", err)
+		}
+		if err := rows.Next(make([]driver.Value, 1)); err != nil {
+			t.Fatalf("read cancellable rows: %v", err)
+		}
+
+		start := make(chan struct{})
+		cancelDone := make(chan struct{})
+		closeDone := make(chan error, 1)
+		go func() {
+			<-start
+			closeDone <- rows.Close()
+		}()
+		go func() {
+			<-start
+			cancel()
+			close(cancelDone)
+		}()
+		close(start)
+		select {
+		case err := <-closeDone:
+			if err != nil {
+				t.Fatalf("close cancellable rows: %v", err)
+			}
+		case <-time.After(contextTestTimeout):
+			t.Fatal("close cancellable rows timed out")
+		}
+		select {
+		case <-cancelDone:
+		case <-time.After(contextTestTimeout):
+			t.Fatal("cancel cancellable rows timed out")
+		}
+
+		reusedRows, err := conn.Query("SELECT 1", nil)
+		if err != nil {
+			t.Fatalf("query reused connection: %v", err)
+		}
+		if err := reusedRows.Next(make([]driver.Value, 1)); err != nil {
+			t.Fatalf("read reused connection: %v", err)
+		}
+		if err := reusedRows.Close(); err != nil {
+			t.Fatalf("close reused rows: %v", err)
+		}
+	}
+}
+
+func TestRowsContextPanicClearsActiveRows(t *testing.T) {
+	conn := openContextTestConn(t)
+	const panicValue = "context test panic"
+	if err := conn.RegisterFunc("context_cancel_panic", func() int64 {
+		panic(panicValue)
+	}, false); err != nil {
+		t.Fatalf("register function: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rows, err := conn.QueryContext(ctx, "SELECT context_cancel_panic()", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	var gotPanic any
+	func() {
+		defer func() {
+			gotPanic = recover()
+		}()
+		_ = rows.Next(make([]driver.Value, 1))
+	}()
+	if gotPanic != panicValue {
+		t.Fatalf("Next panic = %v, want %q", gotPanic, panicValue)
+	}
+
+	conn.mu.Lock()
+	activeRows := conn.activeRows
+	conn.mu.Unlock()
+	if activeRows != nil {
+		t.Fatalf("active rows = %p, want nil", activeRows)
+	}
+}
+
+func TestDatabaseSQLRowsContextCancelAndReuse(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	sqlConn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("get database connection: %v", err)
+	}
+	defer sqlConn.Close()
+
+	var started <-chan struct{}
+	var stopQuery func()
+	if err := sqlConn.Raw(func(driverConn any) error {
+		sqliteConn, ok := driverConn.(*SQLiteConn)
+		if !ok {
+			return fmt.Errorf("driver connection type = %T, want *SQLiteConn", driverConn)
+		}
+		started, stopQuery = registerContextTestQuery(t, sqliteConn)
+		return nil
+	}); err != nil {
+		t.Fatalf("access driver connection: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rows, err := sqlConn.QueryContext(ctx, contextTestControlledQuery, contextTestMaxRows)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	nextDone := make(chan error, 1)
+	go func() {
+		if rows.Next() {
+			nextDone <- errors.New("Next returned a row after cancellation")
+			return
+		}
+		nextDone <- rows.Err()
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		cancel()
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("query did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-nextDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Next error = %v, want context.Canceled", err)
+		}
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("Next did not return after cancellation")
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close rows: %v", err)
+	}
+
+	var got int
+	if err := sqlConn.QueryRowContext(context.Background(), "SELECT 1").Scan(&got); err != nil {
+		t.Fatalf("query reused connection: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("reused query = %d, want 1", got)
+	}
+}
+
+func registerContextTestQuery(tb testing.TB, conn *SQLiteConn) (<-chan struct{}, func()) {
+	tb.Helper()
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	var keepRunning atomic.Bool
+	keepRunning.Store(true)
+	if err := conn.RegisterFunc("context_cancel_continue", func() int64 {
+		startedOnce.Do(func() { close(started) })
+		if keepRunning.Load() {
+			return 1
+		}
+		return 0
+	}, false); err != nil {
+		tb.Fatalf("register function: %v", err)
+	}
+	return started, func() {
+		keepRunning.Store(false)
+	}
+}
+
+func stopContextTestQuery(tb testing.TB, stop func(), nextDone <-chan error) error {
+	tb.Helper()
+	stop()
+	select {
+	case err := <-nextDone:
+		return err
+	case <-time.After(contextTestTimeout):
+		tb.Fatal("controlled query did not stop")
+		return nil
+	}
+}
+
+func contextTestQueryArgs(maxRows int64) []driver.NamedValue {
+	return []driver.NamedValue{{Ordinal: 1, Value: maxRows}}
+}
+
+func BenchmarkRowsContext(b *testing.B) {
+	conn := openContextTestConn(b)
+	if _, err := conn.Exec(`
+		CREATE TABLE benchmark_rows(value INTEGER PRIMARY KEY);
+		WITH RECURSIVE numbers(value) AS (
+			VALUES(1)
+			UNION ALL
+			SELECT value + 1 FROM numbers WHERE value < 1000
+		)
+		INSERT INTO benchmark_rows SELECT value FROM numbers`, nil); err != nil {
+		b.Fatalf("populate benchmark rows: %v", err)
+	}
+	stmtDriver, err := conn.Prepare("SELECT value FROM benchmark_rows LIMIT ?")
+	if err != nil {
+		b.Fatalf("prepare: %v", err)
+	}
+	defer stmtDriver.Close()
+	stmt := stmtDriver.(*SQLiteStmt)
+
+	contexts := []struct {
+		name string
+		new  func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name: "non_cancelable",
+			new: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+		},
+		{
+			name: "cancelable",
+			new: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+		},
+	}
+
+	for _, rowCount := range []int64{0, 1, 1000} {
+		for _, benchmarkContext := range contexts {
+			b.Run(fmt.Sprintf("rows=%d/context=%s", rowCount, benchmarkContext.name), func(b *testing.B) {
+				ctx, cancel := benchmarkContext.new()
+				defer cancel()
+				args := []driver.NamedValue{{Ordinal: 1, Value: rowCount}}
+				values := make([]driver.Value, 1)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					rows, err := stmt.QueryContext(ctx, args)
+					if err != nil {
+						b.Fatalf("query: %v", err)
+					}
+					gotRows := int64(0)
+					for {
+						err := rows.Next(values)
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						if err != nil {
+							b.Fatalf("Next: %v", err)
+						}
+						gotRows++
+					}
+					if err := rows.Close(); err != nil {
+						b.Fatalf("close rows: %v", err)
+					}
+					if gotRows != rowCount {
+						b.Fatalf("row count = %d, want %d", gotRows, rowCount)
+					}
+				}
+				b.ReportMetric(float64(rowCount), "rows/op")
+			})
+		}
+	}
+
+	for _, benchmarkContext := range contexts {
+		b.Run(fmt.Sprintf("close_without_next/context=%s", benchmarkContext.name), func(b *testing.B) {
+			ctx, cancel := benchmarkContext.new()
+			defer cancel()
+			args := []driver.NamedValue{{Ordinal: 1, Value: int64(1)}}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, err := stmt.QueryContext(ctx, args)
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+				if err := rows.Close(); err != nil {
+					b.Fatalf("close rows: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func openContextTestConn(tb testing.TB) *SQLiteConn {
+	tb.Helper()
+	rawConn, err := (&SQLiteDriver{}).Open(":memory:")
+	if err != nil {
+		tb.Fatalf("open SQLite connection: %v", err)
+	}
+	conn := rawConn.(*SQLiteConn)
+	tb.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			tb.Errorf("close SQLite connection: %v", err)
+		}
+	})
+	return conn
+}


### PR DESCRIPTION
## Summary

When `QueryContext` receives a cancellable context, `SQLiteRows.Next` currently creates a goroutine and channel for every row: [current implementation](https://github.com/mattn/go-sqlite3/blob/f9fc7aaf8779eaf4d274010f4b068da1990fd9ed/sqlite3.go#L2574-L2608).

This PR replaces that per-row coordination with:

- synchronous calls to `sqlite3_step`
- one lazily registered `context.AfterFunc` callback per result set
- a connection-guarded Rows identity that rejects callbacks from idle, closed, or reused result sets

Non-cancellable reads retain the direct stepping path.

This builds on the allocation analysis and interrupt-test gap identified in [PR #1295](https://github.com/mattn/go-sqlite3/pull/1295), as well as the semaphore simplification in [PR #1386](https://github.com/mattn/go-sqlite3/pull/1386). Both retain a watcher goroutine for each `Next`; this changes the watcher lifetime to once per result set.

## Benchmarks

Apple M4 Max, Go 1.26.5, 10 interleaved runs at 500 ms per benchmark. Base and PR binaries were alternated, and medians were compared with `benchstat`. `~` means no statistically significant difference at p=0.05. The new benchmark was applied unchanged to upstream commit `f9fc7aa` for the base results.

### `BenchmarkRowsContext` (new)

| Benchmark | Base | This PR | Change |
|---|---:|---:|---:|
| `BenchmarkRowsContext/rows=0/context=non_cancelable` | 831 ns | 832 ns | ~ |
| `BenchmarkRowsContext/rows=0/context=cancelable` | 1.61 µs | **971 ns** | **-39.7%** |
| `BenchmarkRowsContext/rows=1/context=non_cancelable` | 975 ns | 969 ns | ~ |
| `BenchmarkRowsContext/rows=1/context=cancelable` | 2.20 µs | **1.13 µs** | **-48.7%** |
| `BenchmarkRowsContext/rows=1000/context=non_cancelable` | 94.0 µs | 93.6 µs | ~ |
| `BenchmarkRowsContext/rows=1000/context=cancelable` | 462 µs | **103 µs** | **-77.7%** |
| `BenchmarkRowsContext/close_without_next/context=non_cancelable` | 187 ns | 192 ns | +2.7% |
| `BenchmarkRowsContext/close_without_next/context=cancelable` | 189 ns | 192 ns | ~ |

For cancellable traversal, allocations fall from 7 to 4 at one row and from 3,749 to 749 at 1,000 rows. At 1,000 rows, allocation volume falls from 193.6 KiB/op to 6.08 KiB/op.

Outside the cancellable path, allocation counts are unchanged. Adding the callback field moves `SQLiteRows` from the 96-byte to the 112-byte allocation class, adding 16 B/op to benchmarks that allocate one result set. Callback registration is lazy, so closing without calling `Next` remains one allocation.

### Existing benchmarks

| Benchmark | Base | This PR | Change |
|---|---:|---:|---:|
| `BenchmarkHandleLookupParallel` | 0.342 ns | 0.351 ns | ~ |
| `BenchmarkHandleLookupBeforeAfter/before_mutex` | 90.7 ns | 91.2 ns | ~ |
| `BenchmarkHandleLookupBeforeAfter/after_atomic` | 0.241 ns | 0.240 ns | ~ |
| `BenchmarkStmtCache/off` | 1.01 µs | 1.00 µs | ~ |
| `BenchmarkStmtCache/size4_keys1_hit` | 467 ns | 462 ns | ~ |
| `BenchmarkStmtCache/size4_keys4_hit` | 475 ns | 470 ns | ~ |
| `BenchmarkStmtCache/size4_keys8_evict` | 1.10 µs | 1.09 µs | ~ |
| `BenchmarkStmtCache/size16_keys8_hit` | 475 ns | 472 ns | ~ |
| `BenchmarkStmtCache/size16_keys32_evict` | 1.20 µs | 1.20 µs | ~ |
| `BenchmarkCustomFunctions` | 1.70 µs | 1.71 µs | ~ |
| `BenchmarkSuite/BenchmarkExec` | 538 ns | 538 ns | ~ |
| `BenchmarkSuite/BenchmarkQuery` | 1.84 µs | 1.83 µs | ~ |
| `BenchmarkSuite/BenchmarkParams` | 1.98 µs | 1.98 µs | ~ |
| `BenchmarkSuite/BenchmarkStmt` | 953 ns | 947 ns | ~ |
| `BenchmarkSuite/BenchmarkRows` | 50.5 µs | 50.5 µs | ~ |
| `BenchmarkSuite/BenchmarkStmtRows` | 48.5 µs | 48.3 µs | ~ |
| `BenchmarkSuite/BenchmarkQueryParallel` | 890 ns | 901 ns | +1.3% |

Of the 17 pre-existing timing benchmarks, 16 are statistically unchanged; `BenchmarkSuite/BenchmarkQueryParallel` is +1.3%.

## Cancellation behavior

Like the current implementation, cancellation can race immediately before `sqlite3_step` begins. An interrupt issued in that window is a no-op, so the step may finish before `Next` returns the context error.

Tests cover interruption during an in-progress step, cancellation between rows, stale callbacks, prepared-statement reuse, panic cleanup inside `sqlite3_step`, concurrent cancellation with `Rows.Close`, and end-to-end `database/sql` cancellation with physical connection reuse. Removing the interrupt call makes the in-progress-step test fail. The full suite passes under the race detector with the default, `libsqlite3`, full feature-tag, and `sqlite_vacuum_full` configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling during SQLite row iteration.
  - Ensured cancellation interrupts only the active query and does not affect reused or inactive statements.
  - Improved cleanup when rows are closed, canceled, or interrupted concurrently.
  - Preserved reliable connection reuse after canceled operations.

- **Performance**
  - Reduced overhead for cancellable row iteration by avoiding an additional goroutine for each `Next` call.

- **Tests**
  - Added coverage for cancellation during and between rows, concurrent close operations, panic cleanup, and connection reuse.
  - Added benchmarks for cancellable and non-cancellable row iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->