### PR TITLE
Combine row stepping and column collection

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -220,6 +220,18 @@ _sqlite3_prepare_v2_internal(sqlite3 *db, const char *zSql, int nBytes, sqlite3_
 }
 #endif
 
+// Combined step + column value collection in a single C call to reduce
+// CGO crossings while iterating rows.
+static int
+_sqlite3_step_column_values_internal(sqlite3_stmt *stmt, int ncol, sqlite3_go_col *cols)
+{
+  int rv = _sqlite3_step_internal(stmt);
+  if (rv == SQLITE_ROW && ncol > 0) {
+    _sqlite3_column_values(stmt, ncol, cols);
+  }
+  return rv;
+}
+
 void _sqlite3_result_text(sqlite3_context* ctx, const char* s, int n) {
   sqlite3_result_text(ctx, s, n, &free);
 }
@@ -2624,7 +2636,7 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 
 	if rc.stopCancellation == nil {
 		if rc.ctx.Done() == nil {
-			rv := C._sqlite3_step_internal(rc.s.s)
+			rv := C._sqlite3_step_column_values_internal(rc.s.s, C.int(len(dest)), rc.colvals)
 			return rc.readStepResultLocked(dest, rv)
 		}
 		conn := rc.s.c
@@ -2635,7 +2647,7 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 	if err := rc.ctx.Err(); err != nil {
 		return err
 	}
-	rv := rc.stepCancellableLocked()
+	rv := rc.stepCancellableLocked(dest)
 	err := rc.readStepResultLocked(dest, rv)
 	if ctxErr := rc.ctx.Err(); ctxErr != nil {
 		return ctxErr
@@ -2643,10 +2655,10 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 	return err
 }
 
-func (rc *SQLiteRows) stepCancellableLocked() C.int {
+func (rc *SQLiteRows) stepCancellableLocked(dest []driver.Value) C.int {
 	rc.startStepping()
 	defer rc.finishStepping()
-	return C._sqlite3_step_internal(rc.s.s)
+	return C._sqlite3_step_column_values_internal(rc.s.s, C.int(len(dest)), rc.colvals)
 }
 
 func (rc *SQLiteRows) readStepResultLocked(dest []driver.Value, rv C.int) error {
@@ -2665,7 +2677,6 @@ func (rc *SQLiteRows) readStepResultLocked(dest []driver.Value, rv C.int) error 
 	if len(dest) == 0 {
 		return nil
 	}
-	C._sqlite3_column_values(rc.s.s, C.int(len(dest)), rc.colvals)
 	colvals := (*[(math.MaxInt32 - 1) / unsafe.Sizeof(C.sqlite3_go_col{})]C.sqlite3_go_col)(unsafe.Pointer(rc.colvals))[:len(dest):len(dest)]
 
 	decltype := rc.decltype

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -445,8 +445,11 @@ type SQLiteDriver struct {
 
 // SQLiteConn implements driver.Conn.
 type SQLiteConn struct {
-	mu          sync.Mutex
-	db          *C.sqlite3
+	mu sync.Mutex
+	db *C.sqlite3
+	// activeRows identifies the cancellable Rows currently calling sqlite3_step.
+	// It is guarded by mu so a stale cancellation cannot interrupt later work.
+	activeRows  *SQLiteRows
 	loc         *time.Location
 	txlock      string
 	funcs       []*functionInfo
@@ -492,14 +495,15 @@ type SQLiteResult struct {
 
 // SQLiteRows implements driver.Rows.
 type SQLiteRows struct {
-	s        *SQLiteStmt
-	nc       int32 // Number of columns
-	cls      bool  // True if we need to close the parent statement in Close
-	cols     []string
-	decltype []string
-	colvals  *C.sqlite3_go_col
-	ctx      context.Context // no better alternative to pass context into Next() method
-	closemu  sync.Mutex
+	s                *SQLiteStmt
+	nc               int32 // Number of columns
+	cls              bool  // True if we need to close the parent statement in Close
+	cols             []string
+	decltype         []string
+	colvals          *C.sqlite3_go_col
+	ctx              context.Context // no better alternative to pass context into Next() method
+	stopCancellation func() bool
+	closemu          sync.Mutex
 }
 
 type functionInfo struct {
@@ -2466,6 +2470,7 @@ func (s *SQLiteStmt) Readonly() bool {
 func (rc *SQLiteRows) Close() error {
 	rc.closemu.Lock()
 	defer rc.closemu.Unlock()
+	rc.stopWatchingCancellation()
 	s := rc.s
 	if s == nil {
 		if rc.colvals != nil {
@@ -2495,6 +2500,40 @@ func (rc *SQLiteRows) Close() error {
 	}
 	s.mu.Unlock()
 	return nil
+}
+
+func (c *SQLiteConn) interruptActiveRows(rows *SQLiteRows) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeRows == rows && c.db != nil {
+		C.sqlite3_interrupt(c.db)
+	}
+}
+
+func (rc *SQLiteRows) stopWatchingCancellation() {
+	if rc.stopCancellation == nil {
+		return
+	}
+	// A false return is harmless: a callback already in progress can interrupt
+	// only while rc owns conn.activeRows, which is guarded by conn.mu.
+	rc.stopCancellation()
+	rc.stopCancellation = nil
+}
+
+func (rc *SQLiteRows) startStepping() {
+	conn := rc.s.c
+	conn.mu.Lock()
+	conn.activeRows = rc
+	conn.mu.Unlock()
+}
+
+func (rc *SQLiteRows) finishStepping() {
+	conn := rc.s.c
+	conn.mu.Lock()
+	if conn.activeRows == rc {
+		conn.activeRows = nil
+	}
+	conn.mu.Unlock()
 }
 
 func (s *SQLiteStmt) cacheMetadata() bool {
@@ -2583,33 +2622,34 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
-	if rc.ctx.Done() == nil {
-		return rc.nextSyncLocked(dest)
-	}
-	sema := make(chan struct{})
-	var err error
-	go func() {
-		err = rc.nextSyncLocked(dest)
-		close(sema)
-	}()
-	select {
-	case <-sema:
-		return err
-	case <-rc.ctx.Done():
-		select {
-		case <-sema: // no need to interrupt
-		default:
-			// this is still racy and can be no-op if executed between sqlite3_* calls in nextSyncLocked.
-			C.sqlite3_interrupt(rc.s.c.db)
-			<-sema // ensure goroutine completed
+	if rc.stopCancellation == nil {
+		if rc.ctx.Done() == nil {
+			rv := C._sqlite3_step_internal(rc.s.s)
+			return rc.readStepResultLocked(dest, rv)
 		}
-		return rc.ctx.Err()
+		conn := rc.s.c
+		rc.stopCancellation = context.AfterFunc(rc.ctx, func() {
+			conn.interruptActiveRows(rc)
+		})
 	}
+	if err := rc.ctx.Err(); err != nil {
+		return err
+	}
+	rv := rc.stepCancellableLocked()
+	err := rc.readStepResultLocked(dest, rv)
+	if ctxErr := rc.ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }
 
-// nextSyncLocked moves cursor to next; must be called with locked mutex.
-func (rc *SQLiteRows) nextSyncLocked(dest []driver.Value) error {
-	rv := C._sqlite3_step_internal(rc.s.s)
+func (rc *SQLiteRows) stepCancellableLocked() C.int {
+	rc.startStepping()
+	defer rc.finishStepping()
+	return C._sqlite3_step_internal(rc.s.s)
+}
+
+func (rc *SQLiteRows) readStepResultLocked(dest []driver.Value, rv C.int) error {
 	if rv == C.SQLITE_DONE {
 		return io.EOF
 	}

--- a/sqlite3_context_test.go
+++ b/sqlite3_context_test.go
@@ -1,0 +1,479 @@
+//go:build cgo
+// +build cgo
+
+package sqlite3
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const contextTestTimeout = 5 * time.Second
+const contextTestMaxRows = int64(1 << 60)
+
+const contextTestControlledQuery = `
+	WITH RECURSIVE numbers(value) AS (
+		VALUES(0)
+		UNION ALL
+		SELECT value + 1 FROM numbers
+		WHERE value < ? AND context_cancel_continue()
+	)
+	SELECT sum(value) FROM numbers`
+
+func TestRowsContextCancelDuringStep(t *testing.T) {
+	conn := openContextTestConn(t)
+	started, stopQuery := registerContextTestQuery(t, conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rows, err := conn.QueryContext(ctx, contextTestControlledQuery, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- rows.Next(make([]driver.Value, 1))
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		cancel()
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("query did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-nextDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Next error = %v, want context.Canceled", err)
+		}
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("Next did not return after cancellation")
+	}
+}
+
+func TestRowsContextCancelBetweenRows(t *testing.T) {
+	conn := openContextTestConn(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	rows, err := conn.QueryContext(ctx, "SELECT 1 UNION ALL SELECT 2", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	values := make([]driver.Value, 1)
+	if err := rows.Next(values); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+	cancel()
+	if err := rows.Next(values); !errors.Is(err, context.Canceled) {
+		t.Fatalf("second Next error = %v, want context.Canceled", err)
+	}
+}
+
+func TestRowsInterruptIgnoresInactiveRows(t *testing.T) {
+	conn := openContextTestConn(t)
+
+	idleCtx, cancelIdle := context.WithCancel(context.Background())
+	defer cancelIdle()
+	idleRows, err := conn.QueryContext(idleCtx, "SELECT 1 UNION ALL SELECT 2", nil)
+	if err != nil {
+		t.Fatalf("query idle rows: %v", err)
+	}
+	defer idleRows.Close()
+	if err := idleRows.Next(make([]driver.Value, 1)); err != nil {
+		t.Fatalf("read idle rows: %v", err)
+	}
+
+	started, stopQuery := registerContextTestQuery(t, conn)
+	activeCtx, cancelActive := context.WithCancel(context.Background())
+	defer cancelActive()
+	activeRows, err := conn.QueryContext(activeCtx, contextTestControlledQuery, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query active rows: %v", err)
+	}
+	defer activeRows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- activeRows.Next(make([]driver.Value, 1))
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("active query did not start")
+	}
+
+	// Invoke the callback guard directly so the test does not depend on scheduling.
+	conn.interruptActiveRows(idleRows.(*SQLiteRows))
+	if err := stopContextTestQuery(t, stopQuery, nextDone); err != nil {
+		t.Fatalf("active query was interrupted: %v", err)
+	}
+}
+
+func TestRowsLateInterruptDoesNotAffectReusedStatement(t *testing.T) {
+	conn := openContextTestConn(t)
+	started, stopQuery := registerContextTestQuery(t, conn)
+	stmtDriver, err := conn.Prepare(contextTestControlledQuery)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	defer stmtDriver.Close()
+	stmt := stmtDriver.(*SQLiteStmt)
+
+	oldCtx, cancelOld := context.WithCancel(context.Background())
+	defer cancelOld()
+	oldRows, err := stmt.QueryContext(oldCtx, contextTestQueryArgs(0))
+	if err != nil {
+		t.Fatalf("query old rows: %v", err)
+	}
+	if err := oldRows.Next(make([]driver.Value, 1)); err != nil {
+		t.Fatalf("read old rows: %v", err)
+	}
+	if err := oldRows.Close(); err != nil {
+		t.Fatalf("close old rows: %v", err)
+	}
+
+	newCtx, cancelNew := context.WithCancel(context.Background())
+	defer cancelNew()
+	newRows, err := stmt.QueryContext(newCtx, contextTestQueryArgs(contextTestMaxRows))
+	if err != nil {
+		t.Fatalf("query new rows: %v", err)
+	}
+	defer newRows.Close()
+
+	nextDone := make(chan error, 1)
+	go func() {
+		nextDone <- newRows.Next(make([]driver.Value, 1))
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("replacement query did not start")
+	}
+
+	// Simulate a callback that started before oldRows was closed.
+	conn.interruptActiveRows(oldRows.(*SQLiteRows))
+	if err := stopContextTestQuery(t, stopQuery, nextDone); err != nil {
+		t.Fatalf("replacement query was interrupted: %v", err)
+	}
+}
+
+func TestRowsContextCancelAndClose(t *testing.T) {
+	conn := openContextTestConn(t)
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		rows, err := conn.QueryContext(ctx, "SELECT 1 UNION ALL SELECT 2", nil)
+		if err != nil {
+			t.Fatalf("query cancellable rows: %v", err)
+		}
+		if err := rows.Next(make([]driver.Value, 1)); err != nil {
+			t.Fatalf("read cancellable rows: %v", err)
+		}
+
+		start := make(chan struct{})
+		cancelDone := make(chan struct{})
+		closeDone := make(chan error, 1)
+		go func() {
+			<-start
+			closeDone <- rows.Close()
+		}()
+		go func() {
+			<-start
+			cancel()
+			close(cancelDone)
+		}()
+		close(start)
+		select {
+		case err := <-closeDone:
+			if err != nil {
+				t.Fatalf("close cancellable rows: %v", err)
+			}
+		case <-time.After(contextTestTimeout):
+			t.Fatal("close cancellable rows timed out")
+		}
+		select {
+		case <-cancelDone:
+		case <-time.After(contextTestTimeout):
+			t.Fatal("cancel cancellable rows timed out")
+		}
+
+		reusedRows, err := conn.Query("SELECT 1", nil)
+		if err != nil {
+			t.Fatalf("query reused connection: %v", err)
+		}
+		if err := reusedRows.Next(make([]driver.Value, 1)); err != nil {
+			t.Fatalf("read reused connection: %v", err)
+		}
+		if err := reusedRows.Close(); err != nil {
+			t.Fatalf("close reused rows: %v", err)
+		}
+	}
+}
+
+func TestRowsContextPanicClearsActiveRows(t *testing.T) {
+	conn := openContextTestConn(t)
+	const panicValue = "context test panic"
+	if err := conn.RegisterFunc("context_cancel_panic", func() int64 {
+		panic(panicValue)
+	}, false); err != nil {
+		t.Fatalf("register function: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rows, err := conn.QueryContext(ctx, "SELECT context_cancel_panic()", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	var gotPanic any
+	func() {
+		defer func() {
+			gotPanic = recover()
+		}()
+		_ = rows.Next(make([]driver.Value, 1))
+	}()
+	if gotPanic != panicValue {
+		t.Fatalf("Next panic = %v, want %q", gotPanic, panicValue)
+	}
+
+	conn.mu.Lock()
+	activeRows := conn.activeRows
+	conn.mu.Unlock()
+	if activeRows != nil {
+		t.Fatalf("active rows = %p, want nil", activeRows)
+	}
+}
+
+func TestDatabaseSQLRowsContextCancelAndReuse(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	sqlConn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("get database connection: %v", err)
+	}
+	defer sqlConn.Close()
+
+	var started <-chan struct{}
+	var stopQuery func()
+	if err := sqlConn.Raw(func(driverConn any) error {
+		sqliteConn, ok := driverConn.(*SQLiteConn)
+		if !ok {
+			return fmt.Errorf("driver connection type = %T, want *SQLiteConn", driverConn)
+		}
+		started, stopQuery = registerContextTestQuery(t, sqliteConn)
+		return nil
+	}); err != nil {
+		t.Fatalf("access driver connection: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rows, err := sqlConn.QueryContext(ctx, contextTestControlledQuery, contextTestMaxRows)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	nextDone := make(chan error, 1)
+	go func() {
+		if rows.Next() {
+			nextDone <- errors.New("Next returned a row after cancellation")
+			return
+		}
+		nextDone <- rows.Err()
+	}()
+	select {
+	case <-started:
+	case <-time.After(contextTestTimeout):
+		cancel()
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("query did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-nextDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Next error = %v, want context.Canceled", err)
+		}
+	case <-time.After(contextTestTimeout):
+		_ = stopContextTestQuery(t, stopQuery, nextDone)
+		t.Fatal("Next did not return after cancellation")
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close rows: %v", err)
+	}
+
+	var got int
+	if err := sqlConn.QueryRowContext(context.Background(), "SELECT 1").Scan(&got); err != nil {
+		t.Fatalf("query reused connection: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("reused query = %d, want 1", got)
+	}
+}
+
+func registerContextTestQuery(tb testing.TB, conn *SQLiteConn) (<-chan struct{}, func()) {
+	tb.Helper()
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	var keepRunning atomic.Bool
+	keepRunning.Store(true)
+	if err := conn.RegisterFunc("context_cancel_continue", func() int64 {
+		startedOnce.Do(func() { close(started) })
+		if keepRunning.Load() {
+			return 1
+		}
+		return 0
+	}, false); err != nil {
+		tb.Fatalf("register function: %v", err)
+	}
+	return started, func() {
+		keepRunning.Store(false)
+	}
+}
+
+func stopContextTestQuery(tb testing.TB, stop func(), nextDone <-chan error) error {
+	tb.Helper()
+	stop()
+	select {
+	case err := <-nextDone:
+		return err
+	case <-time.After(contextTestTimeout):
+		tb.Fatal("controlled query did not stop")
+		return nil
+	}
+}
+
+func contextTestQueryArgs(maxRows int64) []driver.NamedValue {
+	return []driver.NamedValue{{Ordinal: 1, Value: maxRows}}
+}
+
+func BenchmarkRowsContext(b *testing.B) {
+	conn := openContextTestConn(b)
+	if _, err := conn.Exec(`
+		CREATE TABLE benchmark_rows(value INTEGER PRIMARY KEY);
+		WITH RECURSIVE numbers(value) AS (
+			VALUES(1)
+			UNION ALL
+			SELECT value + 1 FROM numbers WHERE value < 1000
+		)
+		INSERT INTO benchmark_rows SELECT value FROM numbers`, nil); err != nil {
+		b.Fatalf("populate benchmark rows: %v", err)
+	}
+	stmtDriver, err := conn.Prepare("SELECT value FROM benchmark_rows LIMIT ?")
+	if err != nil {
+		b.Fatalf("prepare: %v", err)
+	}
+	defer stmtDriver.Close()
+	stmt := stmtDriver.(*SQLiteStmt)
+
+	contexts := []struct {
+		name string
+		new  func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name: "non_cancelable",
+			new: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+		},
+		{
+			name: "cancelable",
+			new: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+		},
+	}
+
+	for _, rowCount := range []int64{0, 1, 1000} {
+		for _, benchmarkContext := range contexts {
+			b.Run(fmt.Sprintf("rows=%d/context=%s", rowCount, benchmarkContext.name), func(b *testing.B) {
+				ctx, cancel := benchmarkContext.new()
+				defer cancel()
+				args := []driver.NamedValue{{Ordinal: 1, Value: rowCount}}
+				values := make([]driver.Value, 1)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					rows, err := stmt.QueryContext(ctx, args)
+					if err != nil {
+						b.Fatalf("query: %v", err)
+					}
+					gotRows := int64(0)
+					for {
+						err := rows.Next(values)
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						if err != nil {
+							b.Fatalf("Next: %v", err)
+						}
+						gotRows++
+					}
+					if err := rows.Close(); err != nil {
+						b.Fatalf("close rows: %v", err)
+					}
+					if gotRows != rowCount {
+						b.Fatalf("row count = %d, want %d", gotRows, rowCount)
+					}
+				}
+				b.ReportMetric(float64(rowCount), "rows/op")
+			})
+		}
+	}
+
+	for _, benchmarkContext := range contexts {
+		b.Run(fmt.Sprintf("close_without_next/context=%s", benchmarkContext.name), func(b *testing.B) {
+			ctx, cancel := benchmarkContext.new()
+			defer cancel()
+			args := []driver.NamedValue{{Ordinal: 1, Value: int64(1)}}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				rows, err := stmt.QueryContext(ctx, args)
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+				if err := rows.Close(); err != nil {
+					b.Fatalf("close rows: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func openContextTestConn(tb testing.TB) *SQLiteConn {
+	tb.Helper()
+	rawConn, err := (&SQLiteDriver{}).Open(":memory:")
+	if err != nil {
+		tb.Fatalf("open SQLite connection: %v", err)
+	}
+	conn := rawConn.(*SQLiteConn)
+	tb.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			tb.Errorf("close SQLite connection: %v", err)
+		}
+	})
+	return conn
+}


### PR DESCRIPTION
Depends on #1444. [Incremental diff](https://github.com/bradengroom/go-sqlite3/compare/codex/efficient-query-cancellation...codex/fuse-step-column-values). I will rebase this once the dependency PR lands.

## Summary

`SQLiteRows.Next` currently crosses cgo once to call `sqlite3_step` and, for every returned row, a second time to collect its column values. This PR combines both operations in one C helper.

It retains the same row buffer, conversions, error handling, and cancellation tracking; the helper collects values only when `sqlite3_step` returns `SQLITE_ROW`.

## Benchmarks

Apple M4 Max, Go 1.26.5, 10 interleaved runs at 500 ms per benchmark. Medians were compared with `benchstat`; `~` means no statistically significant difference at p=0.05. Base is `840a3ec` and this PR is `0869632`.

| Benchmark | Base | This PR | Change |
|---|---:|---:|---:|
| `RowsContext/rows=1/context=non_cancelable` | 994 ns | 981 ns | -1.3% |
| `RowsContext/rows=1/context=cancelable` | 1.146 µs | 1.144 µs | ~ |
| `RowsContext/rows=1000/context=non_cancelable` | 96.0 µs | **77.7 µs** | **-19.1%** |
| `RowsContext/rows=1000/context=cancelable` | 104.3 µs | **85.2 µs** | **-18.3%** |
| `BenchmarkSuite/BenchmarkQuery` | 1.854 µs | 1.834 µs | -1.1% |
| `BenchmarkSuite/BenchmarkRows` | 52.0 µs | **50.2 µs** | **-3.5%** |
| `BenchmarkSuite/BenchmarkStmtRows` | 49.7 µs | **47.2 µs** | **-5.0%** |

Bytes and allocations per operation are unchanged in every measured benchmark.