### PR TITLE
fix: keep vtab handle registered when xDestroy fails

### DIFF
--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -423,8 +423,15 @@ func goVRelease(pVTab unsafe.Pointer, isDestroy C.int) *C.char {
 	} else {
 		err = vt.vTab.Disconnect()
 	}
-	// The vtab is gone as far as SQLite is concerned regardless of the
-	// callback result, so release the handle either way.
+	if err != nil && isDestroy == 1 {
+		// SQLite retains p->pVtab when xDestroy fails and later calls
+		// xDisconnect on the same object; keep the handle registered so
+		// that call can resolve it (a missing handle panics above).
+		return mPrintf("%s", err.Error())
+	}
+	// On xDisconnect (success or error) SQLite discards the vtab object,
+	// and on successful xDestroy it clears p->pVtab; release the handle
+	// in both cases.
 	deleteHandle(pVTab)
 	if err != nil {
 		return mPrintf("%s", err.Error())

--- a/sqlite3_opt_vtable_destroy_test.go
+++ b/sqlite3_opt_vtable_destroy_test.go
@@ -1,0 +1,85 @@
+//go:build sqlite_vtable || vtable
+// +build sqlite_vtable vtable
+
+package sqlite3
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+type destroyErrModule struct{}
+
+type destroyErrVTab struct{}
+
+func (m destroyErrModule) Create(c *SQLiteConn, args []string) (VTab, error) {
+	if err := c.DeclareVTab("CREATE TABLE x(test TEXT)"); err != nil {
+		return nil, err
+	}
+	return &destroyErrVTab{}, nil
+}
+func (m destroyErrModule) Connect(c *SQLiteConn, args []string) (VTab, error) {
+	return m.Create(c, args)
+}
+func (m destroyErrModule) DestroyModule() {}
+
+func (v *destroyErrVTab) BestIndex(cst []InfoConstraint, ob []InfoOrderBy) (*IndexResult, error) {
+	return &IndexResult{Used: make([]bool, len(cst)), EstimatedCost: 100}, nil
+}
+func (v *destroyErrVTab) Disconnect() error { return nil }
+func (v *destroyErrVTab) Destroy() error    { return errors.New("boom: destroy refused") }
+func (v *destroyErrVTab) Open() (VTabCursor, error) {
+	return &destroyErrCursor{}, nil
+}
+
+type destroyErrCursor struct{}
+
+func (c *destroyErrCursor) Close() error { return nil }
+func (c *destroyErrCursor) Filter(idxNum int, idxStr string, vals []any) error {
+	return nil
+}
+func (c *destroyErrCursor) Next() error                      { return nil }
+func (c *destroyErrCursor) EOF() bool                        { return true }
+func (c *destroyErrCursor) Column(*SQLiteContext, int) error { return nil }
+func (c *destroyErrCursor) Rowid() (int64, error)            { return 0, nil }
+
+var destroyErrDriverSeq int32
+
+// TestVTabDestroyErrorThenClose: when xDestroy fails, SQLite retains the
+// vtab object and later calls xDisconnect on it during close. The handle
+// must stay registered for that call; deleting it on the error path made
+// Close panic with a failed type assertion.
+func TestVTabDestroyErrorThenClose(t *testing.T) {
+	// Unique driver name so repeated runs (e.g. -count=2) do not panic on
+	// duplicate registration.
+	driverName := fmt.Sprintf("sqlite3_destroy_err_%d", atomic.AddInt32(&destroyErrDriverSeq, 1))
+	sql.Register(driverName, &SQLiteDriver{
+		ConnectHook: func(conn *SQLiteConn) error {
+			return conn.CreateModule("boom", destroyErrModule{})
+		},
+	})
+	db, err := sql.Open(driverName, filepath.Join(t.TempDir(), "vtab.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE VIRTUAL TABLE vtab USING boom()"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query("SELECT * FROM vtab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows.Close()
+
+	if _, err := db.Exec("DROP TABLE vtab"); err == nil {
+		t.Fatal("DROP TABLE unexpectedly succeeded with an erroring Destroy")
+	}
+	// Must not panic.
+	if err := db.Close(); err != nil {
+		t.Logf("close err: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
When a virtual table's `VTab.Destroy()` (`xDestroy`) returns an error, SQLite **retains** `p->pVtab` (it only clears the pointer inside `if (rc == SQLITE_OK)` in `sqlite3VtabCallDestroy`) and later calls `xDisconnect` on the same object during unlock/close.

`goVRelease` deleted the Go-side handle regardless of the callback result, so that later `xDisconnect` hit `lookupHandle` -> nil and panicked with a failed type assertion (`interface conversion: interface {} is nil, not *sqlite3.sqliteVTab`) while closing the connection.

## Reproduction (before)

```go
// module whose Destroy() returns an error
db.Exec("CREATE VIRTUAL TABLE vtab USING boom()")
db.Exec("DROP TABLE vtab")        // returns the Destroy error - fine
db.Close()                        // PANIC
```

## Fix
Release the handle only after a successful `xDestroy`; on any `xDisconnect` (success or error) keep releasing as before, since SQLite always discards the object there.

## Test
`TestVTabDestroyErrorThenClose` (build tag `sqlite_vtable`): errors on DROP, then asserts Close completes without panic - it panics on the pre-fix code and passes with the fix. Full `-tags sqlite_vtable` suite green.

Found during the 0xCarbon fork's SQLCipher 4.17 sync review (external review + empirical verification).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual-table cleanup when destruction reports an error.
  - Prevented potential crashes when closing a database after a failed virtual-table removal.

- **Tests**
  - Added regression coverage for failed virtual-table destruction followed by database closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->