### PR TITLE
fix: drop stmt cache after schema-changing Exec

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -978,8 +978,10 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []driver.Named
 			}
 			start += na
 		}
+		current := query
 		tail := s.(*SQLiteStmt).t
 		s.Close()
+		c.dropStmtCacheIfSchemaChanged(current)
 		if tail == "" {
 			if res == nil {
 				// https://github.com/mattn/go-sqlite3/issues/963
@@ -995,6 +997,7 @@ func (c *SQLiteConn) exec(ctx context.Context, query string, args []driver.Named
 func (c *SQLiteConn) execNoArgs(query string) (driver.Result, error) {
 	var res *SQLiteResult
 	for len(query) > 0 {
+		current := query
 		var rowid, changes C.longlong
 		var tail *C.char
 		pquery := C.CString(query)
@@ -1009,6 +1012,7 @@ func (c *SQLiteConn) execNoArgs(query string) (driver.Result, error) {
 			return nil, c.lastError()
 		}
 		res = &SQLiteResult{id: int64(rowid), changes: int64(changes)}
+		c.dropStmtCacheIfSchemaChanged(current)
 	}
 	if res == nil {
 		res = &SQLiteResult{0, 0}
@@ -1948,6 +1952,7 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 		// caller gets a stmt equivalent to a fresh Prepare.
 		s.closed = false
 		s.cls = false
+		s.metadata = nil
 		return s
 	}
 	return nil
@@ -1989,6 +1994,43 @@ func (c *SQLiteConn) closeCachedStmtsLocked() {
 		finalizeCachedStmt(s)
 	}
 	c.stmtCache = c.stmtCache[:0]
+}
+
+// dropStmtCacheIfSchemaChanged discards cached statements after DDL.
+// SQLite auto-reprepares an expired sqlite3_stmt on the next step, but
+// sqlite3_column_count and the names captured at Query time still describe
+// the old schema until that happens. Exec of ALTER/CREATE/DROP etc. does not
+// go through the cache, so without this a later cache hit returns stale
+// columns (see #1447).
+func (c *SQLiteConn) dropStmtCacheIfSchemaChanged(query string) {
+	if c == nil || !c.stmtCacheEnabled || !schemaChangingQuery(query) {
+		return
+	}
+	c.mu.Lock()
+	c.closeCachedStmtsLocked()
+	c.mu.Unlock()
+}
+
+func schemaChangingQuery(query string) bool {
+	q := strings.TrimSpace(query)
+	i := 0
+	for i < len(q) {
+		ch := q[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' {
+			i++
+			continue
+		}
+		break
+	}
+	if i == 0 {
+		return false
+	}
+	switch strings.ToUpper(q[:i]) {
+	case "ALTER", "CREATE", "DROP", "ATTACH", "DETACH", "REINDEX", "VACUUM":
+		return true
+	default:
+		return false
+	}
 }
 
 // finalizeCachedStmt tears down a stmt that was sitting in the connection's

--- a/sqlite3_stmt_cache_test.go
+++ b/sqlite3_stmt_cache_test.go
@@ -10,6 +10,8 @@ package sqlite3
 
 import (
 	"context"
+	"database/sql/driver"
+	"reflect"
 	"testing"
 )
 
@@ -131,6 +133,94 @@ func TestStmtCacheReuseReturnsSameHandle(t *testing.T) {
 
 	if h1 != h2 {
 		t.Fatalf("expected cached prepare to reuse sqlite3_stmt handle, got %p vs %p", h1, h2)
+	}
+}
+
+// TestStmtCacheExpiredAfterAlter is the #1447 regression: SELECT * is cached,
+// ALTER TABLE adds a column via execNoArgs (which does not touch the cache),
+// and the next SELECT * must not return the pre-ALTER column list.
+func TestStmtCacheExpiredAfterAlter(t *testing.T) {
+	d := SQLiteDriver{}
+	conn, err := d.Open(":memory:?_stmt_cache_size=8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := conn.(*SQLiteConn)
+	if _, err := c.Exec("CREATE TABLE t (a TEXT)", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := c.Query("SELECT * FROM t", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := rows.Columns(), []string{"a"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("before ALTER: Columns() = %v, want %v", got, want)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if cacheCount(c, "SELECT * FROM t") != 1 {
+		t.Fatalf("expected SELECT * to be cached after Close, cache=%#v", cacheKeys(c))
+	}
+
+	if _, err := c.Exec("ALTER TABLE t ADD COLUMN b TEXT", nil); err != nil {
+		t.Fatal(err)
+	}
+	if cacheCount(c, "SELECT * FROM t") != 0 {
+		t.Fatalf("ALTER should drop the cached SELECT *, cache=%#v", cacheKeys(c))
+	}
+
+	rows, err = c.Query("SELECT * FROM t", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	if got, want := rows.Columns(), []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("after ALTER: Columns() = %v, want %v", got, want)
+	}
+}
+
+// TestStmtCacheSurvivesInsert checks that DML does not discard the cache.
+func TestStmtCacheSurvivesInsert(t *testing.T) {
+	d := SQLiteDriver{}
+	conn, err := d.Open(":memory:?_stmt_cache_size=4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	c := conn.(*SQLiteConn)
+	if _, err := c.Exec("CREATE TABLE t (a TEXT)", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	const q = "SELECT * FROM t"
+	stmt1, err := c.prepareWithCache(context.Background(), q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1 := stmt1.(*SQLiteStmt).s
+	if err := stmt1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.Exec("INSERT INTO t (a) VALUES (?)", []driver.Value{"x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stmt2, err := c.prepareWithCache(context.Background(), q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2 := stmt2.(*SQLiteStmt).s
+	if err := stmt2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Fatalf("INSERT should not evict a cached SELECT, got %p vs %p", h1, h2)
 	}
 }
 


### PR DESCRIPTION
## Summary

With `_stmt_cache_size` enabled, `SELECT * FROM t` is cached. `ALTER TABLE` goes through `execNoArgs`, which never touches that cache, so the next `SELECT *` still reports the pre-ALTER columns even though SQLite has already added the new one.

Drop the cache after schema-changing SQL (`ALTER`, `CREATE`, `DROP`, `ATTACH`, `DETACH`, `REINDEX`, `VACUUM`). Ordinary DML is left alone so a hot `SELECT` still reuses the handle.

Fixes #1447

## Test plan

- [x] `TestStmtCacheExpiredAfterAlter`: `SELECT *`, `ALTER TABLE ... ADD COLUMN`, `SELECT *` returns both columns
- [x] `TestStmtCacheSurvivesInsert`: parameterized `INSERT` does not evict the cached `SELECT`
- [x] existing `TestStmtCache*` still pass (`CGO_ENABLED=1 go test -run TestStmtCache .`)