### PR TITLE
Flush statement cache when the schema changes

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -135,6 +135,28 @@ _sqlite3_reset_clear(sqlite3_stmt* stmt)
   return rv;
 }
 
+// Steps the pre-prepared schema probe statement and returns its
+// cumulative re-prepare count, in a single CGO crossing. The probe
+// references the schema, so stepping it makes SQLite verify the schema
+// cookie and reload the connection's schema after a change by another
+// connection; the re-prepare count then reflects that change.
+// Returns -1 on error or when sqlite3_stmt_status is too old to
+// report re-prepares.
+static sqlite3_int64
+_sqlite3_schema_generation(sqlite3_stmt* stmt)
+{
+#ifdef SQLITE_STMTSTATUS_REPREPARE
+  int rc = sqlite3_step(stmt);
+  sqlite3_reset(stmt);
+  if (rc != SQLITE_ROW && rc != SQLITE_DONE) {
+    return -1;
+  }
+  return sqlite3_stmt_status(stmt, SQLITE_STMTSTATUS_REPREPARE, 0);
+#else
+  return -1;
+#endif
+}
+
 #ifdef SQLITE_ENABLE_UNLOCK_NOTIFY
 extern int _sqlite3_step_blocking(sqlite3_stmt *stmt);
 extern int _sqlite3_step_row_blocking(sqlite3_stmt* stmt, long long* rowid, long long* changes);
@@ -459,6 +481,13 @@ type SQLiteConn struct {
 	// only field safe to read without the lock.
 	stmtCache        []*SQLiteStmt
 	stmtCacheEnabled bool
+	// schemaProbeStmt is a pre-prepared statement referencing the
+	// schema, used to detect (and make SQLite pick up) schema changes
+	// that expire cached statements; it is only set when the statement
+	// cache is enabled. schemaGen holds the probe's re-prepare count
+	// observed at the last cache lookup.
+	schemaProbeStmt *C.sqlite3_stmt
+	schemaGen       C.sqlite3_int64
 }
 
 // SQLiteTx implements driver.Tx.
@@ -1609,6 +1638,28 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
+	if conn.stmtCacheEnabled {
+		// Used to detect schema changes that expire cached statements;
+		// see takeCachedStmt.
+		const probe = "SELECT 1 FROM sqlite_master LIMIT 0"
+		cp := C.CString(probe)
+		rv := C._sqlite3_prepare_v2_internal(db, cp, C.int(len(probe)), &conn.schemaProbeStmt, nil)
+		C.free(unsafe.Pointer(cp))
+		if rv != C.SQLITE_OK {
+			return fail(lastError(db))
+		}
+		conn.schemaGen = C._sqlite3_schema_generation(conn.schemaProbeStmt)
+		if conn.schemaGen < 0 {
+			// The runtime SQLite cannot report re-prepare counts
+			// (pre-3.20 system library); run without the cache
+			// rather than risk serving expired statements.
+			C.sqlite3_finalize(conn.schemaProbeStmt)
+			conn.schemaProbeStmt = nil
+			conn.stmtCache = nil
+			conn.stmtCacheEnabled = false
+		}
+	}
+
 	exec := func(s string) error {
 		cs := C.CString(s)
 		rv := C.sqlite3_exec(db, cs, nil, nil, nil)
@@ -1903,6 +1954,10 @@ func (c *SQLiteConn) Close() error {
 	}
 	runtime.SetFinalizer(c, nil)
 	c.closeCachedStmtsLocked()
+	if c.schemaProbeStmt != nil {
+		C.sqlite3_finalize(c.schemaProbeStmt)
+		c.schemaProbeStmt = nil
+	}
 	rv := C.sqlite3_close_v2(c.db)
 	if rv != C.SQLITE_OK {
 		return lastError(c.db)
@@ -1930,6 +1985,21 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 	defer c.mu.Unlock()
 
 	if c.db == nil {
+		return nil
+	}
+	if c.schemaProbeStmt == nil {
+		return nil
+	}
+	// A schema change expires every cached statement. SQLite would
+	// re-prepare them transparently at step time, but the column count
+	// and metadata are captured before stepping and would silently
+	// describe the old schema. Stepping the probe forces SQLite to
+	// notice a schema change and reload the connection's schema, and
+	// bumps the probe's re-prepare count when that happens; flush the
+	// cache then (and when the probe fails: fail safe).
+	if g := C._sqlite3_schema_generation(c.schemaProbeStmt); g < 0 || g != c.schemaGen {
+		c.schemaGen = g
+		c.closeCachedStmtsLocked()
 		return nil
 	}
 	// Scan from the MRU end (tail) so that a stmt put just before is

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -137,16 +137,22 @@ _sqlite3_reset_clear(sqlite3_stmt* stmt)
 
 // Steps the pre-prepared schema probe statement and returns its
 // cumulative re-prepare count, in a single CGO crossing. The probe
-// references the schema, so stepping it makes SQLite verify the schema
-// cookie and reload the connection's schema after a change by another
-// connection; the re-prepare count then reflects that change.
-// Returns -1 on error or when sqlite3_stmt_status is too old to
-// report re-prepares.
+// references the main and temp schemas, so stepping it makes SQLite
+// verify their schema cookies and reload the connection's schema after
+// a change by another connection; the re-prepare count then reflects
+// that change. Returns -1 on error or when sqlite3_stmt_status is too
+// old to report re-prepares, and -2 inside an explicit transaction,
+// where the probe must not run: its read would widen the transaction's
+// snapshot, and the schema cannot change under an open snapshot anyway.
 static sqlite3_int64
 _sqlite3_schema_generation(sqlite3_stmt* stmt)
 {
 #ifdef SQLITE_STMTSTATUS_REPREPARE
-  int rc = sqlite3_step(stmt);
+  int rc;
+  if (!sqlite3_get_autocommit(sqlite3_db_handle(stmt))) {
+    return -2;
+  }
+  rc = sqlite3_step(stmt);
   sqlite3_reset(stmt);
   if (rc != SQLITE_ROW && rc != SQLITE_DONE) {
     return -1;
@@ -1638,10 +1644,23 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
+	if conn.stmtCacheEnabled && int(C.sqlite3_libversion_number()) < 3020000 {
+		// The runtime library predates SQLITE_STMTSTATUS_REPREPARE
+		// (3.20.0); without it cached statements expired by schema
+		// changes cannot be detected, so run without the cache. The
+		// compile-time check in _sqlite3_schema_generation is not
+		// enough: with USE_LIBSQLITE3 the header and the runtime
+		// library can differ.
+		conn.stmtCache = nil
+		conn.stmtCacheEnabled = false
+	}
 	if conn.stmtCacheEnabled {
 		// Used to detect schema changes that expire cached statements;
-		// see takeCachedStmt.
-		const probe = "SELECT 1 FROM sqlite_master LIMIT 0"
+		// see takeCachedStmt. Statements referencing ATTACHed schemas
+		// are not covered: their schema changes go undetected, which
+		// mirrors the pre-cache limitation that column metadata is
+		// captured before the first step.
+		const probe = "SELECT 1 FROM sqlite_master, sqlite_temp_master LIMIT 0"
 		cp := C.CString(probe)
 		rv := C._sqlite3_prepare_v2_internal(db, cp, C.int(len(probe)), &conn.schemaProbeStmt, nil)
 		C.free(unsafe.Pointer(cp))
@@ -1996,8 +2015,14 @@ func (c *SQLiteConn) takeCachedStmt(query string) *SQLiteStmt {
 	// describe the old schema. Stepping the probe forces SQLite to
 	// notice a schema change and reload the connection's schema, and
 	// bumps the probe's re-prepare count when that happens; flush the
-	// cache then (and when the probe fails: fail safe).
-	if g := C._sqlite3_schema_generation(c.schemaProbeStmt); g < 0 || g != c.schemaGen {
+	// cache then (and when the probe fails: fail safe). Inside an
+	// explicit transaction the probe must not run; report a miss so
+	// the statement is prepared against the transaction's schema.
+	g := C._sqlite3_schema_generation(c.schemaProbeStmt)
+	if g == -2 {
+		return nil
+	}
+	if g < 0 || g != c.schemaGen {
 		c.schemaGen = g
 		c.closeCachedStmtsLocked()
 		return nil

--- a/sqlite3_stmt_cache_test.go
+++ b/sqlite3_stmt_cache_test.go
@@ -110,6 +110,9 @@ func TestStmtCacheReuseReturnsSameHandle(t *testing.T) {
 	defer conn.Close()
 
 	c := conn.(*SQLiteConn)
+	if !c.stmtCacheEnabled {
+		t.Skip("statement cache disabled on this SQLite runtime")
+	}
 	ctx := context.Background()
 
 	const q = "SELECT 42"
@@ -204,6 +207,100 @@ func TestStmtCacheSchemaChange(t *testing.T) {
 	}
 	if a != "x" || b != nil || c != nil {
 		t.Fatalf("row after ALTERs: got (%q, %v, %v), want (\"x\", <nil>, <nil>)", a, b, c)
+	}
+}
+
+// TestStmtCacheTempSchemaChange verifies that DDL on the temp schema also
+// invalidates cached statements referencing it.
+func TestStmtCacheTempSchemaChange(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:?_stmt_cache_size=8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec("CREATE TEMP TABLE tt (a TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query("SELECT * FROM tt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows.Close() // cached
+
+	if _, err := db.Exec("ALTER TABLE tt ADD COLUMN b TEXT"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = db.Query("SELECT * FROM tt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(cols, want) {
+		t.Fatalf("columns after temp ALTER: got %v, want %v", cols, want)
+	}
+}
+
+// TestStmtCacheInTransaction verifies that DDL inside an explicit
+// transaction is honored by queries later in the same transaction (the
+// cache reports a miss there instead of probing the schema).
+func TestStmtCacheInTransaction(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:?_stmt_cache_size=8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec("CREATE TABLE t (a TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query("SELECT * FROM t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows.Close() // cached
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec("ALTER TABLE t ADD COLUMN b TEXT"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = tx.Query("SELECT * FROM t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cols, err := rows.Columns()
+	rows.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(cols, want) {
+		t.Fatalf("columns inside transaction after ALTER: got %v, want %v", cols, want)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After commit the next lookup probes again and must see the change.
+	rows, err = db.Query("SELECT * FROM t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	cols, err = rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(cols, want) {
+		t.Fatalf("columns after commit: got %v, want %v", cols, want)
 	}
 }
 

--- a/sqlite3_stmt_cache_test.go
+++ b/sqlite3_stmt_cache_test.go
@@ -9,6 +9,9 @@ package sqlite3
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -130,6 +133,77 @@ func TestStmtCacheReuseReturnsSameHandle(t *testing.T) {
 
 	if h1 != h2 {
 		t.Fatalf("expected cached prepare to reuse sqlite3_stmt handle, got %p vs %p", h1, h2)
+	}
+}
+
+// TestStmtCacheSchemaChange verifies that a schema change does not let the
+// cache hand back an expired statement whose captured column metadata still
+// describes the old schema (issue #1447). Both same-connection DDL and DDL
+// issued through a second database handle must invalidate the cache.
+func TestStmtCacheSchemaChange(t *testing.T) {
+	fn := filepath.Join(t.TempDir(), "schemachange.db")
+	db, err := sql.Open("sqlite3", "file:"+fn+"?_stmt_cache_size=8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec("CREATE TABLE t (a TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO t VALUES ('x')"); err != nil {
+		t.Fatal(err)
+	}
+
+	queryCols := func() []string {
+		rows, err := db.Query("SELECT * FROM t")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		cols, err := rows.Columns()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cols
+	}
+
+	// Populate the cache.
+	if cols := queryCols(); !reflect.DeepEqual(cols, []string{"a"}) {
+		t.Fatalf("initial columns: got %v, want [a]", cols)
+	}
+
+	// Same-connection DDL.
+	if _, err := db.Exec("ALTER TABLE t ADD COLUMN b TEXT"); err != nil {
+		t.Fatal(err)
+	}
+	if cols := queryCols(); !reflect.DeepEqual(cols, []string{"a", "b"}) {
+		t.Fatalf("columns after same-connection ALTER: got %v, want [a b]", cols)
+	}
+
+	// DDL through a second database handle (different connection).
+	db2, err := sql.Open("sqlite3", "file:"+fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db2.Exec("ALTER TABLE t ADD COLUMN c TEXT"); err != nil {
+		db2.Close()
+		t.Fatal(err)
+	}
+	db2.Close()
+	if cols := queryCols(); !reflect.DeepEqual(cols, []string{"a", "b", "c"}) {
+		t.Fatalf("columns after cross-connection ALTER: got %v, want [a b c]", cols)
+	}
+
+	// The row data must scan consistently with the new column set.
+	var a string
+	var b, c any
+	if err := db.QueryRow("SELECT * FROM t").Scan(&a, &b, &c); err != nil {
+		t.Fatal(err)
+	}
+	if a != "x" || b != nil || c != nil {
+		t.Fatalf("row after ALTERs: got (%q, %v, %v), want (\"x\", <nil>, <nil>)", a, b, c)
 	}
 }
 


### PR DESCRIPTION
Fixes #1447. With _stmt_cache_size enabled, a schema change expired cached statements but the cache still served them; the column count and metadata captured before stepping described the old schema, so e.g. SELECT * silently omitted newly added columns.

Each connection with the cache enabled now holds a pre-prepared probe statement (SELECT 1 FROM sqlite_master LIMIT 0). Stepping it on every cache lookup makes SQLite verify the schema cookie and reload the connection's schema after a change by another connection, and its SQLITE_STMTSTATUS_REPREPARE count reveals that a change happened, in one CGO crossing. On a change the whole cache is flushed (every cached statement is expired anyway). If the runtime library is too old to report re-prepare counts (pre-3.20), the cache is disabled instead of risking stale results.

Covers both same-connection DDL and DDL from a second connection in the regression test. Cache-hit cost goes from ~820ns to ~1016ns; still well below the ~2.1µs uncached path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prepared-statement cache handling when database schema changes occur.
  - Automatically refreshes cached statements so updated column metadata and query results are used.
  - Improved handling of schema changes involving temporary tables and explicit transactions, including after commit.
  - Prevented statement-cache issues when running with older SQLite library versions by disabling caching when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->