### PR TITLE
Replace copy-on-write handle map with sync.Map

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -29,7 +29,6 @@ import (
 	"math"
 	"reflect"
 	"sync"
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -104,27 +103,28 @@ type handleVal struct {
 	val any
 }
 
-var handleLock sync.Mutex
-var handleVals atomic.Value // stores map[unsafe.Pointer]handleVal
+// handleVals maps unsafe.Pointer handles to handleVal. A sync.Map keeps
+// lookups lock-free on the hot callback path while insertion and removal
+// stay O(1); the previous copy-on-write map made every registration copy
+// the whole table, so opening N connections (each registering several
+// functions) was quadratic in time and allocation.
+var handleVals sync.Map
 
 func newHandle(db *SQLiteConn, v any) unsafe.Pointer {
-	val := handleVal{db: db, val: v}
 	var p unsafe.Pointer = C.malloc(C.size_t(1))
 	if p == nil {
 		panic("can't allocate 'cgo-pointer hack index pointer': ptr == nil")
 	}
-
-	handleLock.Lock()
-	defer handleLock.Unlock()
-
-	next := cloneHandleVals(len(loadHandleVals()) + 1)
-	next[p] = val
-	handleVals.Store(next)
+	handleVals.Store(p, handleVal{db: db, val: v})
 	return p
 }
 
 func lookupHandleVal(handle unsafe.Pointer) handleVal {
-	return loadHandleVals()[handle]
+	v, ok := handleVals.Load(handle)
+	if !ok {
+		return handleVal{}
+	}
+	return v.(handleVal)
 }
 
 func lookupHandle(handle unsafe.Pointer) any {
@@ -134,55 +134,20 @@ func lookupHandle(handle unsafe.Pointer) any {
 // deleteHandle releases a single handle created by newHandle. It is a no-op
 // if the handle is unknown (e.g. already released).
 func deleteHandle(handle unsafe.Pointer) {
-	handleLock.Lock()
-	defer handleLock.Unlock()
-
-	current := loadHandleVals()
-	if _, ok := current[handle]; !ok {
-		return
+	if _, ok := handleVals.LoadAndDelete(handle); ok {
+		C.free(handle)
 	}
-	next := make(map[unsafe.Pointer]handleVal, len(current)-1)
-	for h, v := range current {
-		if h == handle {
-			continue
-		}
-		next[h] = v
-	}
-	handleVals.Store(next)
-	C.free(handle)
 }
 
 func deleteHandles(db *SQLiteConn) {
-	handleLock.Lock()
-	defer handleLock.Unlock()
-
-	current := loadHandleVals()
-	if len(current) == 0 {
-		return
-	}
-
-	next := make(map[unsafe.Pointer]handleVal, len(current))
-	for handle, val := range current {
-		if val.db == db {
-			C.free(handle)
-			continue
+	handleVals.Range(func(handle, val any) bool {
+		if val.(handleVal).db == db {
+			if _, ok := handleVals.LoadAndDelete(handle); ok {
+				C.free(handle.(unsafe.Pointer))
+			}
 		}
-		next[handle] = val
-	}
-	handleVals.Store(next)
-}
-
-func loadHandleVals() map[unsafe.Pointer]handleVal {
-	m, _ := handleVals.Load().(map[unsafe.Pointer]handleVal)
-	return m
-}
-
-func cloneHandleVals(size int) map[unsafe.Pointer]handleVal {
-	next := make(map[unsafe.Pointer]handleVal, size)
-	for handle, val := range loadHandleVals() {
-		next[handle] = val
-	}
-	return next
+		return true
+	})
 }
 
 // This is only here so that tests can refer to it.

--- a/callback_bench_test.go
+++ b/callback_bench_test.go
@@ -48,6 +48,14 @@ func BenchmarkHandleLookupBeforeAfter(b *testing.B) {
 			return after.lookup(handle).val
 		})
 	})
+
+	var syncTable syncMapHandleTable
+	syncTable.vals.Store(handle, value)
+	b.Run("sync_map", func(b *testing.B) {
+		benchmarkHandleLookupParallel(b, func() any {
+			return syncTable.lookup(handle).val
+		})
+	})
 }
 
 func benchmarkHandleLookupParallel(b *testing.B, lookup func() any) {
@@ -72,6 +80,18 @@ func (t *mutexHandleTable) lookup(handle unsafe.Pointer) handleVal {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.vals[handle]
+}
+
+type syncMapHandleTable struct {
+	vals sync.Map
+}
+
+func (t *syncMapHandleTable) lookup(handle unsafe.Pointer) handleVal {
+	v, ok := t.vals.Load(handle)
+	if !ok {
+		return handleVal{}
+	}
+	return v.(handleVal)
 }
 
 type atomicHandleTable struct {

--- a/sqlite3_opt_vtable_leak_test.go
+++ b/sqlite3_opt_vtable_leak_test.go
@@ -11,6 +11,15 @@ import (
 
 var leakCheckDriverSeq int32
 
+func countHandles() int {
+	n := 0
+	handleVals.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 func TestVtabCursorHandleRelease(t *testing.T) {
 	// Use a unique driver name so repeated runs (e.g. -count=2) do not
 	// panic on duplicate registration.
@@ -35,10 +44,10 @@ func TestVtabCursorHandleRelease(t *testing.T) {
 			t.Fatal(err)
 		}
 		if i == 0 {
-			before = len(loadHandleVals())
+			before = countHandles()
 		}
 	}
-	after = len(loadHandleVals())
+	after = countHandles()
 	if after > before {
 		t.Fatalf("handle map grew from %d to %d over repeated cursor open/close", before, after)
 	}


### PR DESCRIPTION
Fixes #1451. Since the copy-on-write handle map (1.14.46), every newHandle copied the whole process-global table; Open registers several functions per connection, so opening and holding N connections was quadratic in time and allocation. A sync.Map keeps lookups lock-free on the hot callback path while insertion and removal are O(1).

Total allocation opening and holding N `:memory:` connections (the issue's reproduction):

| connections held | before | after |
| --- | --- | --- |
| 500 | 208.5 MB | 2.1 MB |
| 1000 | 835.0 MB | 3.9 MB |
| 2000 | 3343.7 MB | 7.5 MB |
| 4000 | 13369.9 MB | 14.4 MB |

After is linear again (~3.6 KB per connection, matching 1.14.45).

Handle lookup on the real callback path (BenchmarkHandleLookupParallel, n=6, benchstat):

| | before | after |
| --- | --- | --- |
| HandleLookupParallel | 1.24 ns ± 8% | 2.07 ns ± 15% |

The +0.8 ns per lookup is noise compared to the cost of any SQLite callback; the old pre-1.14.46 mutex table was 41 ns in the same benchmark (a `sync_map` arm is added to BenchmarkHandleLookupBeforeAfter for the record: mutex 41.07 ns / COW atomic 0.99 ns / sync.Map 2.17 ns).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal callback handle management to reduce overhead during registrations and lookups.
  * Improved cleanup efficiency for callback handles.

* **Tests**
  * Expanded performance benchmarks to cover the updated lookup approach.
  * Strengthened leak detection for virtual-table cursor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->